### PR TITLE
CodeQL workflow tuning

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -11,26 +11,28 @@ jobs:
     name: Analyze with CodeQL
     runs-on: ubuntu-latest
     permissions:
+      actions: read
+      contents: read
       security-events: write
 
     strategy:
       fail-fast: false
       matrix:
-        language: [ 'javascript-typescript' ]
+        language: [ 'typescript' ]
 
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
 
-      - name: Set up Node.js
-        uses: actions/setup-node@v6
-        with:
-          node-version: '20'
-
       - name: Initialize CodeQL
         uses: github/codeql-action/init@v4
         with:
           languages: ${{ matrix.language }}
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: '20'
 
       - name: Install dependencies
         run: npm ci
@@ -40,3 +42,5 @@ jobs:
 
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@v4
+        with:
+          category: "/language:${{ matrix.language }}"


### PR DESCRIPTION
## Problem
CodeQL scan results were not being uploaded to GitHub's security page. The security tab was showing outdated scan information from Sep 3, 2025, despite successful workflow runs.

## Solution
Updated the CodeQL workflow with the following improvements:

1. Changed language matrix from `'javascript-typescript'` to `'typescript'` for proper CodeQL analysis
2. Reordered steps to initialize CodeQL before installing dependencies (CodeQL database needs to be prepared first)
3. Added explicit permissions (`actions: read`, `contents: read`, `security-events: write`)
4. Added category parameter to organize analysis results properly

## Changes
- Updated `.github/workflows/codeql.yml` with corrected workflow configuration

This ensures CodeQL results are properly captured and uploaded to the repository's security page.