### PR TITLE
Project tweaks

### DIFF
--- a/.deploy.example
+++ b/.deploy.example
@@ -1,0 +1,9 @@
+# Copy this file to .deploy and adjust values.
+# .deploy is gitignored and should stay local.
+
+hostname=your.server.example
+username=deploy-user
+# Optional, defaults to your SSH client default (usually 22)
+# ssh-port=2222
+path=/var/www/hevelius
+api-url=https://your.server.example:5001/api

--- a/.gitignore
+++ b/.gitignore
@@ -43,6 +43,9 @@ testem.log
 # OpenAPI spec (synced from backend repo, not committed)
 /api/openapi.yaml
 
+# Local deploy configuration
+.deploy
+
 # System Files
 .DS_Store
 Thumbs.db

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 0.5.0 (unreleased)
 
-- Login auth contract updated: frontend now sends plaintext password over HTTPS for backend verification
+- Login auth contract updated: frontend now sends plaintext password over HTTPS
+  for backend verification
 - Backend password hashing migrated from MD5 to Argon2id
 - Removed `ts-md5` dependency and client-side MD5 hashing code
 - Removed hammerjs dependency
@@ -10,6 +11,8 @@
 - Angular/CDK and other dependencies migrated to 21
 - User profile
 - Gravatar support
+- User experience improved when adding new project: the object is looked up in
+  the catalog and RA/DEC coords are set if found
 
 0.4.0 (2026-03-27)
 
@@ -81,4 +84,5 @@
 
 0.0.1 (2019 Feb)
 
-- Initial version with limited capabilities (login, able to list 10 tasks, without any interpretation)
+- Initial version with limited capabilities (login, able to list 10 tasks,
+  without any interpretation)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@
 - Gravatar support
 - User experience improved when adding new project: the object is looked up in
   the catalog and RA/DEC coords are set if found
+- Massive projects enhancements: subframes presentation improved, added many new
+  fields, sorting, better editing etc.
 
 0.4.0 (2026-03-27)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 0.5.0 (unreleased)
 
+- The projects support added
 - Login auth contract updated: frontend now sends plaintext password over HTTPS
   for backend verification
 - Backend password hashing migrated from MD5 to Argon2id

--- a/angular.json
+++ b/angular.json
@@ -112,6 +112,12 @@
           "options": {
             "script": "scripts/deploy.js"
           }
+        },
+        "sync-openapi": {
+          "builder": "hevelius-deploy-builder:deploy",
+          "options": {
+            "script": "scripts/sync-openapi.js"
+          }
         }
       }
     }

--- a/angular.json
+++ b/angular.json
@@ -106,6 +106,12 @@
               "src/**/*.html"
             ]
           }
+        },
+        "deploy": {
+          "builder": "hevelius-deploy-builder:deploy",
+          "options": {
+            "script": "scripts/deploy.js"
+          }
         }
       }
     }

--- a/doc/devel.md
+++ b/doc/devel.md
@@ -112,3 +112,7 @@ And then use one of the API points, e.g.
 curl -s -H "Authorization: Bearer $TOKEN" "http://localhost:5000/api/sensors?active=false"
 ```
 
+## Syncing the OpenAPI file
+
+Assuming there's a ../hevelius-backend dir (so both hevelius-backend and hevelius-web are siblings),
+you can copy the API definition with `ng run hevelius:sync-openapi`.

--- a/doc/install.md
+++ b/doc/install.md
@@ -21,7 +21,58 @@ Navigate to `http://localhost:4200/`. The app will reload when you change source
 
 You need to have hevelius backend running. See https://github.com/borowka-obs/hevelius-backend for details.
 
-Edit `src/hevelius.ts` to point to your running backend, e.g.
+## Options
+
+1. Manual deployment (edit API URL, run build, copy files manually over SSH/SCP/rsync).
+2. Automated deployment with local `.deploy` file and `ng run hevelius:deploy` (recommended).
+
+## Automated deployment (recommended)
+
+Copy `.deploy.example` to `.deploy` and set your server details:
+
+```bash
+cp .deploy.example .deploy
+```
+
+`.deploy` format:
+
+```bash
+hostname=your.server.example
+username=deploy-user
+# Optional:
+# ssh-port=2222
+path=/var/www/hevelius
+api-url=https://your.server.example:5001/api
+```
+
+Then run:
+
+```bash
+npx ng run hevelius:deploy
+```
+
+or:
+
+```bash
+npm run deploy
+```
+
+This will:
+
+1. Apply `api-url` to `src/hevelius.ts` for the build.
+2. Run `ng build --configuration production`, `ng test`, `ng lint`.
+3. Copy `dist/hevelius/browser/` to `username@hostname:path` using `rsync --delete` (with custom SSH port if `ssh-port` is set).
+4. Print:
+
+```text
+don't forget to run sudo systemctl restart gunicorn-hevelius on the server
+```
+
+The script restores your original local `src/hevelius.ts` after deployment.
+
+## Manual deployment
+
+Edit `src/hevelius.ts` to point to your running backend, for example:
 
 ```typescript
     // Make sure there is no trailing slash
@@ -30,6 +81,6 @@ Edit `src/hevelius.ts` to point to your running backend, e.g.
 
 Then make `ng build`.
 
-The copy over `dist/hevelius/browser/*` to your running server. You might want to
+Then copy over `dist/hevelius/browser/*` to your running server. You might want to
 see [example NGINX config](nginx-deploy.md) for some tips how to deploy on NGINX.
 This is just an example. The app should work on any other web server.

--- a/package-lock.json
+++ b/package-lock.json
@@ -33,6 +33,7 @@
         "@typescript-eslint/eslint-plugin": "^8.57.2",
         "@typescript-eslint/parser": "^8.57.2",
         "eslint": "^9.39.3",
+        "hevelius-deploy-builder": "file:tools/hevelius-deploy-builder",
         "jsdom": "^25.0.0",
         "typescript": "^5.8.3",
         "vitest": "^4.1.2"
@@ -6612,6 +6613,10 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/hevelius-deploy-builder": {
+      "resolved": "tools/hevelius-deploy-builder",
+      "link": true
+    },
     "node_modules/hono": {
       "version": "4.12.8",
       "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.8.tgz",
@@ -10102,6 +10107,13 @@
       "resolved": "https://registry.npmjs.org/zone.js/-/zone.js-0.15.1.tgz",
       "integrity": "sha512-XE96n56IQpJM7NAoXswY3XRLcWFW83xe0BiAOeMD7K5k5xecOeul3Qcpx6GqEeeHNkW5DWL5zOyTbEfB4eti8w==",
       "license": "MIT"
+    },
+    "tools/hevelius-deploy-builder": {
+      "version": "0.0.1",
+      "dev": true,
+      "dependencies": {
+        "@angular-devkit/architect": "^0.2102.4"
+      }
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "build": "ng build",
     "test": "ng test",
     "lint": "ng lint",
+    "deploy": "ng run hevelius:deploy",
     "sync-openapi": "node scripts/sync-openapi.js"
   },
   "private": true,
@@ -32,6 +33,7 @@
     "@angular/build": "^21.2.4",
     "@angular/cli": "^21.2.4",
     "@angular/compiler-cli": "^21.2.6",
+    "hevelius-deploy-builder": "file:tools/hevelius-deploy-builder",
     "@types/node": "^20.0.0",
     "@typescript-eslint/eslint-plugin": "^8.57.2",
     "@typescript-eslint/parser": "^8.57.2",

--- a/scripts/deploy.js
+++ b/scripts/deploy.js
@@ -1,0 +1,158 @@
+#!/usr/bin/env node
+/**
+ * Deploy frontend build to a remote server over SSH.
+ *
+ * Reads configuration from ".deploy" in project root:
+ *   hostname=example.com
+ *   username=deploy
+ *   path=/var/www/hevelius
+ *   api-url=https://example.com:5001/api
+ *   ssh-port=22 (optional)
+ */
+
+const fs = require('fs');
+const path = require('path');
+const { execSync } = require('child_process');
+
+const projectRoot = path.resolve(__dirname, '..');
+const deployConfigPath = path.join(projectRoot, '.deploy');
+const heveliusPath = path.join(projectRoot, 'src', 'hevelius.ts');
+const buildOutputPath = path.join(projectRoot, 'dist', 'hevelius', 'browser') + path.sep;
+
+function parseDeployConfig(raw) {
+  const config = {};
+  const lines = raw.split(/\r?\n/);
+
+  for (const line of lines) {
+    const trimmed = line.trim();
+    if (!trimmed || trimmed.startsWith('#')) {
+      continue;
+    }
+
+    const separatorIndex = trimmed.indexOf('=');
+    if (separatorIndex < 1) {
+      throw new Error(`Invalid line in .deploy: "${line}"`);
+    }
+
+    const key = trimmed.slice(0, separatorIndex).trim();
+    let value = trimmed.slice(separatorIndex + 1).trim();
+
+    if (
+      (value.startsWith('"') && value.endsWith('"')) ||
+      (value.startsWith("'") && value.endsWith("'"))
+    ) {
+      value = value.slice(1, -1);
+    }
+
+    config[key] = value;
+  }
+
+  return config;
+}
+
+function configValue(config, keys) {
+  for (const key of keys) {
+    if (config[key]) {
+      return config[key];
+    }
+  }
+  return '';
+}
+
+function run(command) {
+  console.log(`\n$ ${command}`);
+  execSync(command, {
+    cwd: projectRoot,
+    stdio: 'inherit',
+  });
+}
+
+if (!fs.existsSync(deployConfigPath)) {
+  console.error('Missing .deploy file in project root.');
+  console.error('Copy .deploy.example to .deploy and fill your values.');
+  process.exit(1);
+}
+
+const rawConfig = fs.readFileSync(deployConfigPath, 'utf-8');
+const config = parseDeployConfig(rawConfig);
+
+const hostname = configValue(config, ['hostname', 'host', 'DEPLOY_HOSTNAME']);
+const username = configValue(config, ['username', 'user', 'DEPLOY_USERNAME']);
+const remotePath = configValue(config, ['path', 'remote-path', 'DEPLOY_PATH']);
+const apiUrl = configValue(config, ['api-url', 'api_url', 'API_URL']);
+const sshPort = configValue(config, ['ssh-port', 'ssh_port', 'port', 'DEPLOY_SSH_PORT']);
+
+const missing = [];
+if (!hostname) missing.push('hostname');
+if (!username) missing.push('username');
+if (!remotePath) missing.push('path');
+if (!apiUrl) missing.push('api-url');
+
+if (missing.length > 0) {
+  console.error(`Missing required .deploy settings: ${missing.join(', ')}`);
+  process.exit(1);
+}
+
+if (apiUrl.endsWith('/')) {
+  console.error('Invalid api-url: trailing slash is not allowed.');
+  process.exit(1);
+}
+
+if (sshPort && !/^\d+$/.test(sshPort)) {
+  console.error('Invalid ssh-port: must be a number.');
+  process.exit(1);
+}
+
+if (sshPort) {
+  const portNumber = Number(sshPort);
+  if (portNumber < 1 || portNumber > 65535) {
+    console.error('Invalid ssh-port: must be between 1 and 65535.');
+    process.exit(1);
+  }
+}
+
+if (!fs.existsSync(heveliusPath)) {
+  console.error(`File not found: ${heveliusPath}`);
+  process.exit(1);
+}
+
+const originalHevelius = fs.readFileSync(heveliusPath, 'utf-8');
+
+function setApiUrl(source, nextUrl) {
+  const pattern = /(static\s+apiUrl\s*=\s*)(['"])([^'"]*)(\2)(\s*;)/;
+  if (!pattern.test(source)) {
+    throw new Error('Could not find "static apiUrl = ..." in src/hevelius.ts');
+  }
+  return source.replace(pattern, `$1'${nextUrl}'$5`);
+}
+
+function escapeShellArg(value) {
+  return `'${value.replace(/'/g, `'\\''`)}'`;
+}
+
+try {
+  const updatedHevelius = setApiUrl(originalHevelius, apiUrl);
+  fs.writeFileSync(heveliusPath, updatedHevelius, 'utf-8');
+  console.log(`Updated src/hevelius.ts apiUrl -> ${apiUrl}`);
+
+  run('npx ng build --configuration production');
+  run('npx ng test --watch=false');
+  run('npx ng lint');
+
+  if (!fs.existsSync(buildOutputPath)) {
+    throw new Error(`Build output not found: ${buildOutputPath}`);
+  }
+
+  const remote = `${username}@${hostname}:${remotePath}`;
+  const sshTransport = sshPort ? `-e ${escapeShellArg(`ssh -p ${sshPort}`)}` : '';
+  run(
+    `rsync -avz --delete ${sshTransport} ${escapeShellArg(buildOutputPath)} ${escapeShellArg(remote)}`
+  );
+} finally {
+  fs.writeFileSync(heveliusPath, originalHevelius, 'utf-8');
+  console.log('Restored original src/hevelius.ts');
+}
+
+console.log(
+  "don't forget to run sudo systemctl restart gunicorn-hevelius on the server"
+);

--- a/src/app/app-routing.module.spec.ts
+++ b/src/app/app-routing.module.spec.ts
@@ -1,0 +1,23 @@
+import { routes } from './app-routing.module';
+
+describe('app routes', () => {
+  it('redirects empty authenticated path to projects', () => {
+    const layout = routes.find(r => r.path === '');
+    const children = layout?.children ?? [];
+    const defaultChild = children.find(c => c.path === '');
+    expect(defaultChild?.redirectTo).toBe('projects');
+    expect(defaultChild?.pathMatch).toBe('full');
+  });
+
+  it('redirects unknown paths to /projects', () => {
+    const fallback = routes.find(r => r.path === '**');
+    expect(fallback?.redirectTo).toBe('/projects');
+  });
+
+  it('registers projects and tasks child routes', () => {
+    const layout = routes.find(r => r.path === '');
+    const paths = (layout?.children ?? []).map(c => c.path);
+    expect(paths).toContain('projects');
+    expect(paths).toContain('tasks');
+  });
+});

--- a/src/app/app-routing.module.ts
+++ b/src/app/app-routing.module.ts
@@ -30,8 +30,8 @@ export const routes: Routes = [
       { path: 'projects/:id', component: ProjectDetailComponent },
       { path: 'catalogs', component: CatalogsComponent },
       { path: 'user', component: UserComponent },
-      { path: '', redirectTo: 'tasks', pathMatch: 'full' }
+      { path: '', redirectTo: 'projects', pathMatch: 'full' }
     ]
   },
-  { path: '**', redirectTo: '/tasks' }
+  { path: '**', redirectTo: '/projects' }
 ];

--- a/src/app/components/layout/layout.component.html
+++ b/src/app/components/layout/layout.component.html
@@ -18,6 +18,10 @@
     <mat-icon>menu</mat-icon>
   </button>
   <mat-menu #menu="matMenu">
+    <button mat-menu-item routerLink="/projects">
+      <mat-icon>folder</mat-icon>
+      <span>Projects</span>
+    </button>
     <button mat-menu-item routerLink="/tasks">
       <mat-icon>list</mat-icon>
       <span>Tasks</span>
@@ -37,10 +41,6 @@
     <button mat-menu-item routerLink="/filters">
       <mat-icon>filter_alt</mat-icon>
       <span>Filters</span>
-    </button>
-    <button mat-menu-item routerLink="/projects">
-      <mat-icon>folder</mat-icon>
-      <span>Projects</span>
     </button>
     <button mat-menu-item routerLink="/catalogs">
       <mat-icon>star</mat-icon>

--- a/src/app/components/project-detail/project-detail.component.css
+++ b/src/app/components/project-detail/project-detail.component.css
@@ -37,3 +37,29 @@ table {
 .tasks-heading {
   margin: 0 0 1rem;
 }
+
+.active-row {
+  margin: 0.75rem 0;
+}
+
+.muted {
+  color: rgba(0, 0, 0, 0.54);
+  font-size: 0.85em;
+  margin-left: 0.35rem;
+}
+
+.progress-cell {
+  min-width: 160px;
+  padding: 4px 0;
+}
+
+.progress-cell mat-progress-bar {
+  height: 8px;
+  border-radius: 4px;
+}
+
+.progress-meta {
+  display: block;
+  margin-top: 4px;
+  font-size: 0.85rem;
+}

--- a/src/app/components/project-detail/project-detail.component.html
+++ b/src/app/components/project-detail/project-detail.component.html
@@ -52,6 +52,10 @@
           <th mat-header-cell *matHeaderCellDef>Exposure (s)</th>
           <td mat-cell *matCellDef="let s">{{ s.exposure_time }}</td>
         </ng-container>
+        <ng-container matColumnDef="count">
+          <th mat-header-cell *matHeaderCellDef>Count</th>
+          <td mat-cell *matCellDef="let s">{{ s.count ?? 0 }}</td>
+        </ng-container>
         <ng-container matColumnDef="goal_count">
           <th mat-header-cell *matHeaderCellDef>Goal count</th>
           <td mat-cell *matCellDef="let s">{{ s.goal_count ?? '–' }}</td>

--- a/src/app/components/project-detail/project-detail.component.html
+++ b/src/app/components/project-detail/project-detail.component.html
@@ -73,20 +73,20 @@
           <td mat-cell *matCellDef="let s">{{ s.exposure_time }}</td>
         </ng-container>
         <ng-container matColumnDef="count">
-          <th mat-header-cell *matHeaderCellDef>Count</th>
+          <th mat-header-cell *matHeaderCellDef>Subframes [#]</th>
           <td mat-cell *matCellDef="let s">{{ s.count ?? 0 }}</td>
         </ng-container>
         <ng-container matColumnDef="goal_count">
-          <th mat-header-cell *matHeaderCellDef>Goal count</th>
+          <th mat-header-cell *matHeaderCellDef>Subframes goal [#]</th>
           <td mat-cell *matCellDef="let s">{{ s.goal_count ?? '–' }}</td>
         </ng-container>
-        <ng-container matColumnDef="goal_integration">
-          <th mat-header-cell *matHeaderCellDef>Goal time</th>
-          <td mat-cell *matCellDef="let s">{{ formatDurationSeconds(subGoalSeconds(s)) }}</td>
-        </ng-container>
         <ng-container matColumnDef="captured_integration">
-          <th mat-header-cell *matHeaderCellDef>Captured</th>
+          <th mat-header-cell *matHeaderCellDef>Subframes [s]</th>
           <td mat-cell *matCellDef="let s">{{ formatDurationSeconds(subCapturedSeconds(s)) }}</td>
+        </ng-container>
+        <ng-container matColumnDef="goal_integration">
+          <th mat-header-cell *matHeaderCellDef>Subframes goal [s]</th>
+          <td mat-cell *matCellDef="let s">{{ formatDurationSeconds(subGoalSeconds(s)) }}</td>
         </ng-container>
         <ng-container matColumnDef="progress">
           <th mat-header-cell *matHeaderCellDef>Progress</th>

--- a/src/app/components/project-detail/project-detail.component.html
+++ b/src/app/components/project-detail/project-detail.component.html
@@ -20,12 +20,32 @@
           <a [routerLink]="['/scopes', project.scope_id]">{{ project.scope_id }}</a>)
         </p>
         <p><strong>RA:</strong> {{ formatRA(project.ra) }} <strong>Dec:</strong> {{ formatDec(project.decl) }}</p>
-        <p><strong>Active:</strong> {{ project.active ? 'Yes' : 'No' }}</p>
+        <p class="active-row">
+          <mat-slide-toggle
+            [checked]="project.active"
+            (change)="onProjectActiveChange($event.checked)">
+            Project active
+          </mat-slide-toggle>
+        </p>
+        @if (getSubframes().length) {
+          <p>
+            <strong>Total integration (captured):</strong>
+            {{ formatDurationSeconds(projectCapturedTotalSeconds()) }}
+            <span class="muted">(count × exposure per subframe, summed)</span>
+          </p>
+          <p>
+            <strong>Total integration (goal):</strong>
+            {{ formatDurationSeconds(projectGoalTotalSeconds()) }}
+          </p>
+          @if (projectSummaryLine()) {
+            <p><strong>Plan by filter:</strong> {{ projectSummaryLine() }}</p>
+          }
+        }
 
         <div class="project-actions">
           <button mat-button color="primary" (click)="editProject()" type="button">
             <mat-icon>edit</mat-icon>
-            Edit coordinates / telescope
+            Edit project
           </button>
         </div>
       </mat-card-content>
@@ -59,6 +79,30 @@
         <ng-container matColumnDef="goal_count">
           <th mat-header-cell *matHeaderCellDef>Goal count</th>
           <td mat-cell *matCellDef="let s">{{ s.goal_count ?? '–' }}</td>
+        </ng-container>
+        <ng-container matColumnDef="goal_integration">
+          <th mat-header-cell *matHeaderCellDef>Goal time</th>
+          <td mat-cell *matCellDef="let s">{{ formatDurationSeconds(subGoalSeconds(s)) }}</td>
+        </ng-container>
+        <ng-container matColumnDef="captured_integration">
+          <th mat-header-cell *matHeaderCellDef>Captured</th>
+          <td mat-cell *matCellDef="let s">{{ formatDurationSeconds(subCapturedSeconds(s)) }}</td>
+        </ng-container>
+        <ng-container matColumnDef="progress">
+          <th mat-header-cell *matHeaderCellDef>Progress</th>
+          <td mat-cell *matCellDef="let s">
+            @if (progressPercent(s) != null) {
+              <div class="progress-cell">
+                <mat-progress-bar mode="determinate" [value]="barPercent(s)"></mat-progress-bar>
+                <span class="progress-meta">
+                  {{ progressPercentLabel(s) }}
+                  <span class="muted">({{ s.count ?? 0 }} / {{ s.goal_count }})</span>
+                </span>
+              </div>
+            } @else {
+              —
+            }
+          </td>
         </ng-container>
         <ng-container matColumnDef="active">
           <th mat-header-cell *matHeaderCellDef>Active</th>

--- a/src/app/components/project-detail/project-detail.component.html
+++ b/src/app/components/project-detail/project-detail.component.html
@@ -20,6 +20,16 @@
           <a [routerLink]="['/scopes', project.scope_id]">{{ project.scope_id }}</a>)
         </p>
         <p><strong>RA:</strong> {{ formatRA(project.ra) }} <strong>Dec:</strong> {{ formatDec(project.decl) }}</p>
+        <p><strong>Start date:</strong> {{ formatCalendarDate(project.start_date) }}</p>
+        <p><strong>End date:</strong> {{ formatCalendarDate(project.end_date) }}</p>
+        <p>
+          <strong>Last updated:</strong>
+          @if (project.last_updated) {
+            {{ project.last_updated | date: 'medium' }}
+          } @else {
+            —
+          }
+        </p>
         <p class="active-row">
           <mat-slide-toggle
             [checked]="project.active"
@@ -30,8 +40,10 @@
         @if (getSubframes().length) {
           <p>
             <strong>Total integration (captured):</strong>
-            {{ formatDurationSeconds(projectCapturedTotalSeconds()) }}
-            <span class="muted">(count × exposure per subframe, summed)</span>
+            {{ formatTotalIntegrationFromProject() }}
+            @if (project.total_integration_time === null || project.total_integration_time === undefined) {
+              <span class="muted">(from subframes; API field missing)</span>
+            }
           </p>
           <p>
             <strong>Total integration (goal):</strong>
@@ -60,33 +72,21 @@
         </button>
       </div>
       <table mat-table [dataSource]="getSubframes()" class="mat-elevation-z8">
-        <ng-container matColumnDef="id">
-          <th mat-header-cell *matHeaderCellDef>ID</th>
-          <td mat-cell *matCellDef="let s">{{ s.id }}</td>
-        </ng-container>
         <ng-container matColumnDef="filter">
           <th mat-header-cell *matHeaderCellDef>Filter</th>
           <td mat-cell *matCellDef="let s">{{ s.filter?.short_name ?? s.filter_id }}</td>
         </ng-container>
         <ng-container matColumnDef="exposure_time">
-          <th mat-header-cell *matHeaderCellDef>Exposure (s)</th>
-          <td mat-cell *matCellDef="let s">{{ s.exposure_time }}</td>
-        </ng-container>
-        <ng-container matColumnDef="count">
-          <th mat-header-cell *matHeaderCellDef>Subframes [#]</th>
-          <td mat-cell *matCellDef="let s">{{ s.count ?? 0 }}</td>
+          <th mat-header-cell *matHeaderCellDef>Captured (count × exposure)</th>
+          <td mat-cell *matCellDef="let s">
+            {{ s.count ?? 0 }} × {{ s.exposure_time }}s = {{ formatDurationSeconds(subCapturedSeconds(s)) }}
+          </td>
         </ng-container>
         <ng-container matColumnDef="goal_count">
-          <th mat-header-cell *matHeaderCellDef>Subframes goal [#]</th>
-          <td mat-cell *matCellDef="let s">{{ s.goal_count ?? '–' }}</td>
-        </ng-container>
-        <ng-container matColumnDef="captured_integration">
-          <th mat-header-cell *matHeaderCellDef>Subframes [s]</th>
-          <td mat-cell *matCellDef="let s">{{ formatDurationSeconds(subCapturedSeconds(s)) }}</td>
-        </ng-container>
-        <ng-container matColumnDef="goal_integration">
-          <th mat-header-cell *matHeaderCellDef>Subframes goal [s]</th>
-          <td mat-cell *matCellDef="let s">{{ formatDurationSeconds(subGoalSeconds(s)) }}</td>
+          <th mat-header-cell *matHeaderCellDef>Goal (count × exposure)</th>
+          <td mat-cell *matCellDef="let s">
+            {{ s.goal_count ?? '–' }} × {{ s.exposure_time }}s = {{ formatDurationSeconds(subGoalSeconds(s)) }}
+          </td>
         </ng-container>
         <ng-container matColumnDef="progress">
           <th mat-header-cell *matHeaderCellDef>Progress</th>

--- a/src/app/components/project-detail/project-detail.component.html
+++ b/src/app/components/project-detail/project-detail.component.html
@@ -91,7 +91,7 @@
         <ng-container matColumnDef="progress">
           <th mat-header-cell *matHeaderCellDef>Progress</th>
           <td mat-cell *matCellDef="let s">
-            @if (progressPercent(s) != null) {
+            @if (progressPercent(s) !== null) {
               <div class="progress-cell">
                 <mat-progress-bar mode="determinate" [value]="barPercent(s)"></mat-progress-bar>
                 <span class="progress-meta">

--- a/src/app/components/project-detail/project-detail.component.ts
+++ b/src/app/components/project-detail/project-detail.component.ts
@@ -8,6 +8,8 @@ import { MatCardModule } from '@angular/material/card';
 import { MatTableModule } from '@angular/material/table';
 import { MatButtonModule } from '@angular/material/button';
 import { MatIconModule } from '@angular/material/icon';
+import { MatProgressBarModule } from '@angular/material/progress-bar';
+import { MatSlideToggleModule } from '@angular/material/slide-toggle';
 import { MatSnackBar } from '@angular/material/snack-bar';
 import { MatDialog } from '@angular/material/dialog';
 import { MatTooltipModule } from '@angular/material/tooltip';
@@ -15,6 +17,16 @@ import { SubframeFormDialogComponent } from '../subframe-form-dialog/subframe-fo
 import { CoordsFormatterService } from '../../services/coords-formatter.service';
 import { ProjectEditDialogComponent } from '../project-edit-dialog/project-edit-dialog.component';
 import { TasksComponent } from '../tasks/tasks.component';
+import {
+  formatIntegrationDuration,
+  progressBarPercent,
+  projectFilterGoalSummary,
+  projectTotalCapturedSeconds,
+  projectTotalGoalSeconds,
+  subframeCapturedSeconds,
+  subframeGoalSeconds,
+  subframeProgressPercent
+} from '../../utils/project-integration';
 
 @Component({
   selector: 'app-project-detail',
@@ -28,6 +40,8 @@ import { TasksComponent } from '../tasks/tasks.component';
     MatButtonModule,
     MatIconModule,
     MatTooltipModule,
+    MatProgressBarModule,
+    MatSlideToggleModule,
     TasksComponent
   ]
 })
@@ -43,7 +57,18 @@ export class ProjectDetailComponent implements OnInit {
 
   project: Project | null = null;
   telescope: Telescope | null = null;
-  subframesColumns: string[] = ['id', 'filter', 'exposure_time', 'count', 'goal_count', 'active', 'actions'];
+  subframesColumns: string[] = [
+    'id',
+    'filter',
+    'exposure_time',
+    'count',
+    'goal_count',
+    'goal_integration',
+    'captured_integration',
+    'progress',
+    'active',
+    'actions'
+  ];
 
   ngOnInit(): void {
     const id = this.route.snapshot.paramMap.get('id');
@@ -107,7 +132,8 @@ export class ProjectDetailComponent implements OnInit {
         initialScopeId: this.project.scope_id,
         initialRa: this.project.ra,
         initialDecl: this.project.decl,
-        initialRegexps: this.project.regexps
+        initialRegexps: this.project.regexps,
+        initialActive: this.project.active
       }
     });
     ref.afterClosed().subscribe((updated: boolean | undefined) => {
@@ -167,6 +193,66 @@ export class ProjectDetailComponent implements OnInit {
             });
           }
         });
+      }
+    });
+  }
+
+  formatDurationSeconds(sec: number): string {
+    return formatIntegrationDuration(sec);
+  }
+
+  subGoalSeconds(s: ProjectSubframe): number {
+    return subframeGoalSeconds(s);
+  }
+
+  subCapturedSeconds(s: ProjectSubframe): number {
+    return subframeCapturedSeconds(s);
+  }
+
+  progressPercent(s: ProjectSubframe): number | null {
+    return subframeProgressPercent(s);
+  }
+
+  barPercent(s: ProjectSubframe): number {
+    return progressBarPercent(subframeProgressPercent(s));
+  }
+
+  progressPercentLabel(s: ProjectSubframe): string {
+    const pct = subframeProgressPercent(s);
+    if (pct == null) {
+      return '—';
+    }
+    return `${pct.toFixed(1)}%`;
+  }
+
+  projectCapturedTotalSeconds(): number {
+    return this.project ? projectTotalCapturedSeconds(this.project) : 0;
+  }
+
+  projectGoalTotalSeconds(): number {
+    return this.project ? projectTotalGoalSeconds(this.project) : 0;
+  }
+
+  projectSummaryLine(): string {
+    return this.project ? projectFilterGoalSummary(this.project) : '';
+  }
+
+  onProjectActiveChange(active: boolean): void {
+    if (!this.project) {
+      return;
+    }
+    this.projectsService.updateProject(this.project.project_id, { active }).subscribe({
+      next: updated => {
+        const prev = this.project!;
+        this.project = {
+          ...prev,
+          ...updated,
+          subframes: updated.subframes ?? prev.subframes
+        };
+        this.snackBar.open(active ? 'Project enabled' : 'Project disabled', 'Close', { duration: 2500 });
+      },
+      error: err => {
+        this.snackBar.open(err?.error?.msg || 'Failed to update project', 'Close', { duration: 5000 });
       }
     });
   }

--- a/src/app/components/project-detail/project-detail.component.ts
+++ b/src/app/components/project-detail/project-detail.component.ts
@@ -43,7 +43,7 @@ export class ProjectDetailComponent implements OnInit {
 
   project: Project | null = null;
   telescope: Telescope | null = null;
-  subframesColumns: string[] = ['id', 'filter', 'exposure_time', 'goal_count', 'active', 'actions'];
+  subframesColumns: string[] = ['id', 'filter', 'exposure_time', 'count', 'goal_count', 'active', 'actions'];
 
   ngOnInit(): void {
     const id = this.route.snapshot.paramMap.get('id');
@@ -106,7 +106,8 @@ export class ProjectDetailComponent implements OnInit {
         projectId: this.project.project_id,
         initialScopeId: this.project.scope_id,
         initialRa: this.project.ra,
-        initialDecl: this.project.decl
+        initialDecl: this.project.decl,
+        initialRegexps: this.project.regexps
       }
     });
     ref.afterClosed().subscribe((updated: boolean | undefined) => {
@@ -123,11 +124,12 @@ export class ProjectDetailComponent implements OnInit {
           width: '400px',
           data: { filters, mode: 'add' }
         });
-        dialogRef.afterClosed().subscribe((payload: { filter_id: number; exposure_time: number; goal_count?: number; active: boolean } | undefined) => {
+        dialogRef.afterClosed().subscribe((payload: { filter_id: number; exposure_time: number; count?: number; goal_count?: number; active: boolean } | undefined) => {
           if (payload && this.project) {
             this.projectsService.addSubframe(this.project.project_id, {
               filter_id: payload.filter_id,
               exposure_time: payload.exposure_time,
+              count: payload.count,
               goal_count: payload.goal_count,
               active: payload.active
             }).subscribe({
@@ -152,7 +154,7 @@ export class ProjectDetailComponent implements OnInit {
           width: '400px',
           data: { filters, subframe: sub, mode: 'edit' }
         });
-        dialogRef.afterClosed().subscribe((payload: { filter_id?: number; exposure_time?: number; goal_count?: number; active?: boolean } | undefined) => {
+        dialogRef.afterClosed().subscribe((payload: { filter_id?: number; exposure_time?: number; count?: number; goal_count?: number; active?: boolean } | undefined) => {
           if (payload && this.project) {
             this.projectsService.updateSubframe(this.project.project_id, sub.id, payload).subscribe({
               next: () => {

--- a/src/app/components/project-detail/project-detail.component.ts
+++ b/src/app/components/project-detail/project-detail.component.ts
@@ -1,4 +1,5 @@
 import { Component, OnInit, inject } from '@angular/core';
+import { DatePipe } from '@angular/common';
 import { ActivatedRoute, Router, RouterModule } from '@angular/router';
 import { ProjectsService } from '../../services/projects.service';
 import { FiltersService } from '../../services/filters.service';
@@ -42,6 +43,7 @@ import {
     MatTooltipModule,
     MatProgressBarModule,
     MatSlideToggleModule,
+    DatePipe,
     TasksComponent
   ]
 })
@@ -57,18 +59,8 @@ export class ProjectDetailComponent implements OnInit {
 
   project: Project | null = null;
   telescope: Telescope | null = null;
-  subframesColumns: string[] = [
-    'id',
-    'filter',
-    'exposure_time',
-    'count',
-    'goal_count',
-    'goal_integration',
-    'captured_integration',
-    'progress',
-    'active',
-    'actions'
-  ];
+  /** Must match every `matColumnDef` in the template — extra or missing keys break the table. */
+  subframesColumns: string[] = ['filter', 'exposure_time', 'goal_count', 'progress', 'active', 'actions'];
 
   ngOnInit(): void {
     const id = this.route.snapshot.paramMap.get('id');
@@ -133,7 +125,9 @@ export class ProjectDetailComponent implements OnInit {
         initialRa: this.project.ra,
         initialDecl: this.project.decl,
         initialRegexps: this.project.regexps,
-        initialActive: this.project.active
+        initialActive: this.project.active,
+        initialStartDate: this.project.start_date ?? null,
+        initialEndDate: this.project.end_date ?? null
       }
     });
     ref.afterClosed().subscribe((updated: boolean | undefined) => {
@@ -227,6 +221,26 @@ export class ProjectDetailComponent implements OnInit {
 
   projectCapturedTotalSeconds(): number {
     return this.project ? projectTotalCapturedSeconds(this.project) : 0;
+  }
+
+  /** Prefer `total_integration_time` from the API (see openapi Project schema). */
+  formatTotalIntegrationFromProject(): string {
+    if (!this.project) {
+      return '—';
+    }
+    const t = this.project.total_integration_time;
+    if (t != null && Number.isFinite(Number(t))) {
+      return formatIntegrationDuration(Number(t));
+    }
+    const fallback = projectTotalCapturedSeconds(this.project);
+    return formatIntegrationDuration(fallback);
+  }
+
+  formatCalendarDate(value: string | null | undefined): string {
+    if (value == null || String(value).trim() === '') {
+      return '—';
+    }
+    return String(value).trim().slice(0, 10);
   }
 
   projectGoalTotalSeconds(): number {

--- a/src/app/components/project-edit-dialog/project-edit-dialog.component.html
+++ b/src/app/components/project-edit-dialog/project-edit-dialog.component.html
@@ -1,4 +1,4 @@
-<h2 mat-dialog-title>Edit project coordinates</h2>
+<h2 mat-dialog-title>Edit project</h2>
 <mat-dialog-content>
   <form [formGroup]="form" class="dialog-form">
     <mat-form-field appearance="outline" class="full-width">
@@ -16,15 +16,35 @@
       <mat-hint>This is a space separated list of regular expressions. Optional</mat-hint>
     </mat-form-field>
 
-    <mat-form-field appearance="outline" class="full-width">
+    <mat-form-field appearance="outline" class="full-width" subscriptSizing="dynamic">
       <mat-label>RA (hours)</mat-label>
-      <input matInput type="number" formControlName="ra" min="0" max="24" step="0.001">
+      <input matInput formControlName="ra" placeholder="Decimal or H:M:S" autocomplete="off">
+      <mat-hint>Decimal hours (0–24) or sexagesimal</mat-hint>
+      @if (raSexagesimalHint) {
+        <mat-hint align="end">{{ raSexagesimalHint }}</mat-hint>
+      }
+      @if (form.get('ra')?.touched && form.get('ra')?.hasError('required')) {
+        <mat-error>RA is required</mat-error>
+      } @else if (form.get('ra')?.touched && form.get('ra')?.hasError('raParse')) {
+        <mat-error>Invalid RA</mat-error>
+      }
     </mat-form-field>
 
-    <mat-form-field appearance="outline" class="full-width">
+    <mat-form-field appearance="outline" class="full-width" subscriptSizing="dynamic">
       <mat-label>Dec (degrees)</mat-label>
-      <input matInput type="number" formControlName="decl" min="-90" max="90" step="0.001">
+      <input matInput formControlName="decl" placeholder="Decimal or ±D:M:S" autocomplete="off">
+      <mat-hint>Decimal degrees or sexagesimal</mat-hint>
+      @if (decSexagesimalHint) {
+        <mat-hint align="end">{{ decSexagesimalHint }}</mat-hint>
+      }
+      @if (form.get('decl')?.touched && form.get('decl')?.hasError('required')) {
+        <mat-error>Dec is required</mat-error>
+      } @else if (form.get('decl')?.touched && form.get('decl')?.hasError('decParse')) {
+        <mat-error>Invalid Dec</mat-error>
+      }
     </mat-form-field>
+
+    <mat-checkbox formControlName="active">Project active</mat-checkbox>
   </form>
 </mat-dialog-content>
 

--- a/src/app/components/project-edit-dialog/project-edit-dialog.component.html
+++ b/src/app/components/project-edit-dialog/project-edit-dialog.component.html
@@ -44,6 +44,18 @@
       }
     </mat-form-field>
 
+    <mat-form-field appearance="outline" class="full-width" subscriptSizing="dynamic">
+      <mat-label>Start date</mat-label>
+      <input matInput type="date" formControlName="start_date">
+      <mat-hint>Optional (calendar)</mat-hint>
+    </mat-form-field>
+
+    <mat-form-field appearance="outline" class="full-width" subscriptSizing="dynamic">
+      <mat-label>End date</mat-label>
+      <input matInput type="date" formControlName="end_date">
+      <mat-hint>Optional (calendar)</mat-hint>
+    </mat-form-field>
+
     <mat-checkbox formControlName="active">Project active</mat-checkbox>
   </form>
 </mat-dialog-content>

--- a/src/app/components/project-edit-dialog/project-edit-dialog.component.html
+++ b/src/app/components/project-edit-dialog/project-edit-dialog.component.html
@@ -10,6 +10,12 @@
       </mat-select>
     </mat-form-field>
 
+    <mat-form-field appearance="outline" class="full-width" subscriptSizing="dynamic">
+      <mat-label>Regexps</mat-label>
+      <input matInput formControlName="regexps">
+      <mat-hint>This is a space separated list of regular expressions. Optional</mat-hint>
+    </mat-form-field>
+
     <mat-form-field appearance="outline" class="full-width">
       <mat-label>RA (hours)</mat-label>
       <input matInput type="number" formControlName="ra" min="0" max="24" step="0.001">

--- a/src/app/components/project-edit-dialog/project-edit-dialog.component.ts
+++ b/src/app/components/project-edit-dialog/project-edit-dialog.component.ts
@@ -27,6 +27,8 @@ export interface ProjectEditDialogData {
   initialDecl?: number;
   initialRegexps?: string;
   initialActive?: boolean;
+  initialStartDate?: string | null;
+  initialEndDate?: string | null;
 }
 
 function raFieldValidator(c: AbstractControl): ValidationErrors | null {
@@ -82,12 +84,22 @@ export class ProjectEditDialogComponent {
       this.dialogData.initialDecl != null && Number.isFinite(this.dialogData.initialDecl)
         ? String(this.dialogData.initialDecl)
         : '';
+    const startStr =
+      this.dialogData.initialStartDate != null && String(this.dialogData.initialStartDate).trim() !== ''
+        ? String(this.dialogData.initialStartDate).trim().slice(0, 10)
+        : '';
+    const endStr =
+      this.dialogData.initialEndDate != null && String(this.dialogData.initialEndDate).trim() !== ''
+        ? String(this.dialogData.initialEndDate).trim().slice(0, 10)
+        : '';
     this.form = this.fb.group({
       scope_id: [this.dialogData.initialScopeId, Validators.required],
       regexps: [this.dialogData.initialRegexps ?? ''],
       ra: [raStr, [Validators.required, raFieldValidator]],
       decl: [decStr, [Validators.required, decFieldValidator]],
-      active: [this.dialogData.initialActive ?? true]
+      active: [this.dialogData.initialActive ?? true],
+      start_date: [startStr],
+      end_date: [endStr]
     });
 
     this.telescopeService.getTelescopes().subscribe({
@@ -135,12 +147,16 @@ export class ProjectEditDialogComponent {
       return;
     }
 
+    const sd = String(v.start_date ?? '').trim().slice(0, 10);
+    const ed = String(v.end_date ?? '').trim().slice(0, 10);
     const body: ProjectUpdate = {
       scope_id: Number(v.scope_id),
       regexps: String(v.regexps ?? '').trim(),
       ra,
       decl,
-      active: Boolean(v.active)
+      active: Boolean(v.active),
+      start_date: sd === '' ? null : sd,
+      end_date: ed === '' ? null : ed
     };
 
     this.projectsService.updateProject(this.dialogData.projectId, body).subscribe({

--- a/src/app/components/project-edit-dialog/project-edit-dialog.component.ts
+++ b/src/app/components/project-edit-dialog/project-edit-dialog.component.ts
@@ -1,14 +1,24 @@
 import { Component, inject } from '@angular/core';
-import { FormBuilder, FormGroup, ReactiveFormsModule, Validators } from '@angular/forms';
+import {
+  AbstractControl,
+  FormBuilder,
+  FormGroup,
+  ReactiveFormsModule,
+  ValidationErrors,
+  Validators
+} from '@angular/forms';
 import { MAT_DIALOG_DATA, MatDialogModule, MatDialogRef } from '@angular/material/dialog';
 import { MatFormFieldModule } from '@angular/material/form-field';
 import { MatInputModule } from '@angular/material/input';
 import { MatSelectModule } from '@angular/material/select';
 import { MatButtonModule } from '@angular/material/button';
+import { MatCheckboxModule } from '@angular/material/checkbox';
 import { MatSnackBar } from '@angular/material/snack-bar';
 import { TelescopeService, Telescope } from '../../services/telescope.service';
 import { ProjectsService } from '../../services/projects.service';
 import { ProjectUpdate } from '../../models/project';
+import { CoordsFormatterService } from '../../services/coords-formatter.service';
+import { parseDecDegrees, parseRAHours } from '../../utils/coord-parse';
 
 export interface ProjectEditDialogData {
   projectId: number;
@@ -16,6 +26,23 @@ export interface ProjectEditDialogData {
   initialRa?: number;
   initialDecl?: number;
   initialRegexps?: string;
+  initialActive?: boolean;
+}
+
+function raFieldValidator(c: AbstractControl): ValidationErrors | null {
+  const raw = String(c.value ?? '').trim();
+  if (!raw) {
+    return null;
+  }
+  return parseRAHours(raw) === null ? { raParse: true } : null;
+}
+
+function decFieldValidator(c: AbstractControl): ValidationErrors | null {
+  const raw = String(c.value ?? '').trim();
+  if (!raw) {
+    return null;
+  }
+  return parseDecDegrees(raw) === null ? { decParse: true } : null;
 }
 
 @Component({
@@ -29,7 +56,8 @@ export interface ProjectEditDialogData {
     MatFormFieldModule,
     MatInputModule,
     MatSelectModule,
-    MatButtonModule
+    MatButtonModule,
+    MatCheckboxModule
   ]
 })
 export class ProjectEditDialogComponent {
@@ -39,17 +67,27 @@ export class ProjectEditDialogComponent {
   private telescopeService = inject(TelescopeService);
   private projectsService = inject(ProjectsService);
   private snackBar = inject(MatSnackBar);
+  private coordsFormatter = inject(CoordsFormatterService);
 
   form: FormGroup;
   activeTelescopes: Telescope[] = [];
   saving = false;
 
   constructor() {
+    const raStr =
+      this.dialogData.initialRa != null && Number.isFinite(this.dialogData.initialRa)
+        ? String(this.dialogData.initialRa)
+        : '';
+    const decStr =
+      this.dialogData.initialDecl != null && Number.isFinite(this.dialogData.initialDecl)
+        ? String(this.dialogData.initialDecl)
+        : '';
     this.form = this.fb.group({
       scope_id: [this.dialogData.initialScopeId, Validators.required],
       regexps: [this.dialogData.initialRegexps ?? ''],
-      ra: [this.dialogData.initialRa ?? null, [Validators.required, Validators.min(0), Validators.max(24)]],
-      decl: [this.dialogData.initialDecl ?? null, [Validators.required, Validators.min(-90), Validators.max(90)]]
+      ra: [raStr, [Validators.required, raFieldValidator]],
+      decl: [decStr, [Validators.required, decFieldValidator]],
+      active: [this.dialogData.initialActive ?? true]
     });
 
     this.telescopeService.getTelescopes().subscribe({
@@ -62,20 +100,47 @@ export class ProjectEditDialogComponent {
     });
   }
 
+  get raSexagesimalHint(): string {
+    const parsed = parseRAHours(String(this.form.get('ra')?.value ?? '').trim());
+    if (parsed === null) {
+      return '';
+    }
+    return this.coordsFormatter.formatRA(parsed);
+  }
+
+  get decSexagesimalHint(): string {
+    const parsed = parseDecDegrees(String(this.form.get('decl')?.value ?? '').trim());
+    if (parsed === null) {
+      return '';
+    }
+    return this.coordsFormatter.formatDec(parsed);
+  }
+
   cancel(): void {
     this.dialogRef.close(false);
   }
 
   save(): void {
-    if (this.form.invalid) return;
+    if (this.form.invalid) {
+      this.form.markAllAsTouched();
+      return;
+    }
     this.saving = true;
     const v = this.form.getRawValue();
+    const ra = parseRAHours(String(v.ra).trim());
+    const decl = parseDecDegrees(String(v.decl).trim());
+    if (ra === null || decl === null) {
+      this.saving = false;
+      this.snackBar.open('Invalid RA or Dec', 'Close', { duration: 4000 });
+      return;
+    }
 
     const body: ProjectUpdate = {
       scope_id: Number(v.scope_id),
       regexps: String(v.regexps ?? '').trim(),
-      ra: Number(v.ra),
-      decl: Number(v.decl)
+      ra,
+      decl,
+      active: Boolean(v.active)
     };
 
     this.projectsService.updateProject(this.dialogData.projectId, body).subscribe({
@@ -90,4 +155,3 @@ export class ProjectEditDialogComponent {
     });
   }
 }
-

--- a/src/app/components/project-edit-dialog/project-edit-dialog.component.ts
+++ b/src/app/components/project-edit-dialog/project-edit-dialog.component.ts
@@ -15,6 +15,7 @@ export interface ProjectEditDialogData {
   initialScopeId: number;
   initialRa?: number;
   initialDecl?: number;
+  initialRegexps?: string;
 }
 
 @Component({
@@ -46,6 +47,7 @@ export class ProjectEditDialogComponent {
   constructor() {
     this.form = this.fb.group({
       scope_id: [this.dialogData.initialScopeId, Validators.required],
+      regexps: [this.dialogData.initialRegexps ?? ''],
       ra: [this.dialogData.initialRa ?? null, [Validators.required, Validators.min(0), Validators.max(24)]],
       decl: [this.dialogData.initialDecl ?? null, [Validators.required, Validators.min(-90), Validators.max(90)]]
     });
@@ -71,6 +73,7 @@ export class ProjectEditDialogComponent {
 
     const body: ProjectUpdate = {
       scope_id: Number(v.scope_id),
+      regexps: String(v.regexps ?? '').trim(),
       ra: Number(v.ra),
       decl: Number(v.decl)
     };

--- a/src/app/components/project-form-dialog/project-form-dialog.component.css
+++ b/src/app/components/project-form-dialog/project-form-dialog.component.css
@@ -5,5 +5,6 @@
 mat-dialog-content form {
   display: flex;
   flex-direction: column;
+  gap: 0.5rem;
   min-width: 320px;
 }

--- a/src/app/components/project-form-dialog/project-form-dialog.component.html
+++ b/src/app/components/project-form-dialog/project-form-dialog.component.html
@@ -1,7 +1,7 @@
 <h2 mat-dialog-title>New project</h2>
 <mat-dialog-content>
   <form [formGroup]="form">
-    <mat-form-field appearance="outline" class="full-width">
+    <mat-form-field appearance="outline" class="full-width" subscriptSizing="dynamic">
       <mat-label>Name</mat-label>
       <input
         matInput
@@ -9,13 +9,13 @@
         required
         (keydown.enter)="onNameEnter($event)">
       <mat-hint>
-        Press Enter to fill RA/Dec from the catalog (uses the text above). You can rename the project afterward; coordinates stay as you set them.
+        Press Enter to resolve RA/Dec from the catalog. Renaming the project does not change coordinates.
       </mat-hint>
       @if (catalogLookupPending) {
         <mat-hint align="end">Looking up…</mat-hint>
       }
     </mat-form-field>
-    <mat-form-field appearance="outline" class="full-width">
+    <mat-form-field appearance="outline" class="full-width" subscriptSizing="dynamic">
       <mat-label>Telescope</mat-label>
       <mat-select formControlName="scope_id" required>
         @for (s of scopes; track s.scope_id) {
@@ -23,11 +23,11 @@
         }
       </mat-select>
     </mat-form-field>
-    <mat-form-field appearance="outline" class="full-width">
+    <mat-form-field appearance="outline" class="full-width" subscriptSizing="dynamic">
       <mat-label>Description</mat-label>
       <textarea matInput formControlName="description" rows="2"></textarea>
     </mat-form-field>
-    <mat-form-field appearance="outline" class="full-width">
+    <mat-form-field appearance="outline" class="full-width" subscriptSizing="dynamic">
       <mat-label>RA (hours)</mat-label>
       <input matInput type="number" formControlName="ra" min="0" max="24" step="0.0001">
       <mat-hint>Decimal hours (0–24). Sexagesimal:</mat-hint>
@@ -42,7 +42,7 @@
         <mat-error>RA must be at most 24</mat-error>
       }
     </mat-form-field>
-    <mat-form-field appearance="outline" class="full-width">
+    <mat-form-field appearance="outline" class="full-width" subscriptSizing="dynamic">
       <mat-label>Dec (degrees)</mat-label>
       <input matInput type="number" formControlName="decl" min="-90" max="90" step="0.0001">
       <mat-hint>Decimal degrees (−90 to +90). Sexagesimal:</mat-hint>

--- a/src/app/components/project-form-dialog/project-form-dialog.component.html
+++ b/src/app/components/project-form-dialog/project-form-dialog.component.html
@@ -34,32 +34,28 @@
     </mat-form-field>
     <mat-form-field appearance="outline" class="full-width" subscriptSizing="dynamic">
       <mat-label>RA (hours)</mat-label>
-      <input matInput type="number" formControlName="ra" min="0" max="24" step="0.0001">
-      <mat-hint>Decimal hours (0–24). Sexagesimal:</mat-hint>
+      <input matInput formControlName="ra" placeholder="e.g. 0.712 or 00:42:43.2 or 00h42m43s" autocomplete="off">
+      <mat-hint>Decimal hours (0–24) or sexagesimal (H:M:S or Hh Mm Ss)</mat-hint>
       @if (raSexagesimalHint) {
         <mat-hint align="end">{{ raSexagesimalHint }}</mat-hint>
       }
       @if (form.get('ra')?.touched && form.get('ra')?.hasError('required')) {
         <mat-error>RA is required</mat-error>
-      } @else if (form.get('ra')?.touched && form.get('ra')?.hasError('min')) {
-        <mat-error>RA must be at least 0</mat-error>
-      } @else if (form.get('ra')?.touched && form.get('ra')?.hasError('max')) {
-        <mat-error>RA must be at most 24</mat-error>
+      } @else if (form.get('ra')?.touched && form.get('ra')?.hasError('raParse')) {
+        <mat-error>Invalid RA (use decimal hours or H:M:S)</mat-error>
       }
     </mat-form-field>
     <mat-form-field appearance="outline" class="full-width" subscriptSizing="dynamic">
       <mat-label>Dec (degrees)</mat-label>
-      <input matInput type="number" formControlName="decl" min="-90" max="90" step="0.0001">
-      <mat-hint>Decimal degrees (−90 to +90). Sexagesimal:</mat-hint>
+      <input matInput formControlName="decl" placeholder="e.g. 41.27 or +41:16:12" autocomplete="off">
+      <mat-hint>Decimal degrees (−90…90) or sexagesimal (±D:M:S or D°M′S″)</mat-hint>
       @if (decSexagesimalHint) {
         <mat-hint align="end">{{ decSexagesimalHint }}</mat-hint>
       }
       @if (form.get('decl')?.touched && form.get('decl')?.hasError('required')) {
         <mat-error>Dec is required</mat-error>
-      } @else if (form.get('decl')?.touched && form.get('decl')?.hasError('min')) {
-        <mat-error>Dec must be at least −90</mat-error>
-      } @else if (form.get('decl')?.touched && form.get('decl')?.hasError('max')) {
-        <mat-error>Dec must be at most 90</mat-error>
+      } @else if (form.get('decl')?.touched && form.get('decl')?.hasError('decParse')) {
+        <mat-error>Invalid Dec (use decimal degrees or ±D:M:S)</mat-error>
       }
     </mat-form-field>
     <mat-checkbox formControlName="active">Active</mat-checkbox>

--- a/src/app/components/project-form-dialog/project-form-dialog.component.html
+++ b/src/app/components/project-form-dialog/project-form-dialog.component.html
@@ -28,6 +28,11 @@
       <textarea matInput formControlName="description" rows="2"></textarea>
     </mat-form-field>
     <mat-form-field appearance="outline" class="full-width" subscriptSizing="dynamic">
+      <mat-label>Regexps</mat-label>
+      <input matInput formControlName="regexps">
+      <mat-hint>This is a space separated list of regular expressions. Optional</mat-hint>
+    </mat-form-field>
+    <mat-form-field appearance="outline" class="full-width" subscriptSizing="dynamic">
       <mat-label>RA (hours)</mat-label>
       <input matInput type="number" formControlName="ra" min="0" max="24" step="0.0001">
       <mat-hint>Decimal hours (0–24). Sexagesimal:</mat-hint>

--- a/src/app/components/project-form-dialog/project-form-dialog.component.html
+++ b/src/app/components/project-form-dialog/project-form-dialog.component.html
@@ -58,6 +58,16 @@
         <mat-error>Invalid Dec (use decimal degrees or ±D:M:S)</mat-error>
       }
     </mat-form-field>
+    <mat-form-field appearance="outline" class="full-width" subscriptSizing="dynamic">
+      <mat-label>Start date</mat-label>
+      <input matInput type="date" formControlName="start_date">
+      <mat-hint>Optional</mat-hint>
+    </mat-form-field>
+    <mat-form-field appearance="outline" class="full-width" subscriptSizing="dynamic">
+      <mat-label>End date</mat-label>
+      <input matInput type="date" formControlName="end_date">
+      <mat-hint>Optional</mat-hint>
+    </mat-form-field>
     <mat-checkbox formControlName="active">Active</mat-checkbox>
   </form>
 </mat-dialog-content>

--- a/src/app/components/project-form-dialog/project-form-dialog.component.html
+++ b/src/app/components/project-form-dialog/project-form-dialog.component.html
@@ -3,8 +3,17 @@
   <form [formGroup]="form">
     <mat-form-field appearance="outline" class="full-width">
       <mat-label>Name</mat-label>
-      <input matInput formControlName="name" required>
-      <mat-hint>Object name; if in catalog, RA/Dec are resolved automatically.</mat-hint>
+      <input
+        matInput
+        formControlName="name"
+        required
+        (keydown.enter)="onNameEnter($event)">
+      <mat-hint>
+        Press Enter to fill RA/Dec from the catalog (uses the text above). You can rename the project afterward; coordinates stay as you set them.
+      </mat-hint>
+      @if (catalogLookupPending) {
+        <mat-hint align="end">Looking up…</mat-hint>
+      }
     </mat-form-field>
     <mat-form-field appearance="outline" class="full-width">
       <mat-label>Telescope</mat-label>
@@ -20,18 +29,38 @@
     </mat-form-field>
     <mat-form-field appearance="outline" class="full-width">
       <mat-label>RA (hours)</mat-label>
-      <input matInput type="number" formControlName="ra" min="0" max="24" step="0.001" placeholder="Optional">
-      <mat-hint>Required if name is not in catalog.</mat-hint>
+      <input matInput type="number" formControlName="ra" min="0" max="24" step="0.0001">
+      <mat-hint>Decimal hours (0–24). Sexagesimal:</mat-hint>
+      @if (raSexagesimalHint) {
+        <mat-hint align="end">{{ raSexagesimalHint }}</mat-hint>
+      }
+      @if (form.get('ra')?.touched && form.get('ra')?.hasError('required')) {
+        <mat-error>RA is required</mat-error>
+      } @else if (form.get('ra')?.touched && form.get('ra')?.hasError('min')) {
+        <mat-error>RA must be at least 0</mat-error>
+      } @else if (form.get('ra')?.touched && form.get('ra')?.hasError('max')) {
+        <mat-error>RA must be at most 24</mat-error>
+      }
     </mat-form-field>
     <mat-form-field appearance="outline" class="full-width">
       <mat-label>Dec (degrees)</mat-label>
-      <input matInput type="number" formControlName="decl" min="-90" max="90" step="0.001" placeholder="Optional">
-      <mat-hint>Required if name is not in catalog.</mat-hint>
+      <input matInput type="number" formControlName="decl" min="-90" max="90" step="0.0001">
+      <mat-hint>Decimal degrees (−90 to +90). Sexagesimal:</mat-hint>
+      @if (decSexagesimalHint) {
+        <mat-hint align="end">{{ decSexagesimalHint }}</mat-hint>
+      }
+      @if (form.get('decl')?.touched && form.get('decl')?.hasError('required')) {
+        <mat-error>Dec is required</mat-error>
+      } @else if (form.get('decl')?.touched && form.get('decl')?.hasError('min')) {
+        <mat-error>Dec must be at least −90</mat-error>
+      } @else if (form.get('decl')?.touched && form.get('decl')?.hasError('max')) {
+        <mat-error>Dec must be at most 90</mat-error>
+      }
     </mat-form-field>
     <mat-checkbox formControlName="active">Active</mat-checkbox>
   </form>
 </mat-dialog-content>
 <mat-dialog-actions align="end">
-  <button mat-button (click)="cancel()">Cancel</button>
-  <button mat-raised-button color="primary" (click)="save()">Create</button>
+  <button mat-button type="button" (click)="cancel()">Cancel</button>
+  <button mat-raised-button color="primary" type="button" (click)="save()">Create</button>
 </mat-dialog-actions>

--- a/src/app/components/project-form-dialog/project-form-dialog.component.spec.ts
+++ b/src/app/components/project-form-dialog/project-form-dialog.component.spec.ts
@@ -42,8 +42,8 @@ describe('ProjectFormDialogComponent', () => {
       name: 'M31',
       scope_id: 2,
       description: 'Andromeda',
-      ra: 0.7,
-      decl: 41.2,
+      ra: '0.7',
+      decl: '41.2',
       active: true,
       regexps: null
     });

--- a/src/app/components/project-form-dialog/project-form-dialog.component.spec.ts
+++ b/src/app/components/project-form-dialog/project-form-dialog.component.spec.ts
@@ -1,0 +1,63 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { MAT_DIALOG_DATA, MatDialogRef } from '@angular/material/dialog';
+import { MatSnackBar } from '@angular/material/snack-bar';
+import { of } from 'rxjs';
+import { CatalogsService } from '../../services/catalogs.service';
+import { CoordsFormatterService } from '../../services/coords-formatter.service';
+import { ProjectsService } from '../../services/projects.service';
+import { ProjectFormDialogComponent } from './project-form-dialog.component';
+
+describe('ProjectFormDialogComponent', () => {
+  let component: ProjectFormDialogComponent;
+  let fixture: ComponentFixture<ProjectFormDialogComponent>;
+  let projectsService: { createProject: ReturnType<typeof vi.fn> };
+
+  beforeEach(async () => {
+    projectsService = {
+      createProject: vi.fn().mockReturnValue(of({
+        project_id: 1,
+        project: { project_id: 1, name: 'M31', scope_id: 2, active: true }
+      }))
+    };
+
+    await TestBed.configureTestingModule({
+      imports: [ProjectFormDialogComponent],
+      providers: [
+        { provide: ProjectsService, useValue: projectsService },
+        { provide: CatalogsService, useValue: { searchObjects: vi.fn().mockReturnValue(of([])) } },
+        CoordsFormatterService,
+        { provide: MatDialogRef, useValue: { close: vi.fn() } },
+        { provide: MatSnackBar, useValue: { open: vi.fn() } },
+        { provide: MAT_DIALOG_DATA, useValue: { scopes: [{ scope_id: 2, name: 'Test' }] } }
+      ]
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(ProjectFormDialogComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('sends empty regexps string when not provided', () => {
+    component.form.patchValue({
+      name: 'M31',
+      scope_id: 2,
+      description: 'Andromeda',
+      ra: 0.7,
+      decl: 41.2,
+      active: true,
+      regexps: null
+    });
+
+    component.save();
+
+    expect(projectsService.createProject).toHaveBeenCalledWith({
+      name: 'M31',
+      scope_id: 2,
+      description: 'Andromeda',
+      regexps: '',
+      active: true,
+      ra: 0.7,
+      decl: 41.2
+    });
+  });
+});

--- a/src/app/components/project-form-dialog/project-form-dialog.component.spec.ts
+++ b/src/app/components/project-form-dialog/project-form-dialog.component.spec.ts
@@ -60,4 +60,27 @@ describe('ProjectFormDialogComponent', () => {
       decl: 41.2
     });
   });
+
+  it('includes optional start_date and end_date when set', () => {
+    component.form.patchValue({
+      name: 'M42',
+      scope_id: 2,
+      ra: '1',
+      decl: '10',
+      active: true,
+      regexps: '',
+      start_date: '2026-01-10',
+      end_date: '2026-12-31'
+    });
+
+    component.save();
+
+    expect(projectsService.createProject).toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: 'M42',
+        start_date: '2026-01-10',
+        end_date: '2026-12-31'
+      })
+    );
+  });
 });

--- a/src/app/components/project-form-dialog/project-form-dialog.component.ts
+++ b/src/app/components/project-form-dialog/project-form-dialog.component.ts
@@ -8,6 +8,9 @@ import { MatButtonModule } from '@angular/material/button';
 import { MatCheckboxModule } from '@angular/material/checkbox';
 import { ProjectsService } from '../../services/projects.service';
 import { MatSnackBar } from '@angular/material/snack-bar';
+import { CatalogsService, CatalogObject } from '../../services/catalogs.service';
+import { CoordsFormatterService } from '../../services/coords-formatter.service';
+import { finalize } from 'rxjs/operators';
 
 export interface ProjectFormDialogData {
   scopes: { scope_id: number; name: string }[];
@@ -31,19 +34,22 @@ export interface ProjectFormDialogData {
 export class ProjectFormDialogComponent {
   private fb = inject(FormBuilder);
   private projectsService = inject(ProjectsService);
+  private catalogsService = inject(CatalogsService);
+  private coordsFormatter = inject(CoordsFormatterService);
   private dialogRef = inject(MatDialogRef<ProjectFormDialogComponent>);
   private snackBar = inject(MatSnackBar);
   data = inject<ProjectFormDialogData>(MAT_DIALOG_DATA);
 
   form: FormGroup;
+  catalogLookupPending = false;
 
   constructor() {
     this.form = this.fb.group({
       name: ['', Validators.required],
       scope_id: [null as number | null, Validators.required],
       description: [''],
-      ra: [null as number | null],
-      decl: [null as number | null],
+      ra: [null as number | null, [Validators.required, Validators.min(0), Validators.max(24)]],
+      decl: [null as number | null, [Validators.required, Validators.min(-90), Validators.max(90)]],
       active: [true]
     });
   }
@@ -56,19 +62,112 @@ export class ProjectFormDialogComponent {
     this.dialogRef.close();
   }
 
+  /** Enter in the name field: catalog lookup only (does not run when the name is edited later). */
+  onNameEnter(event: Event): void {
+    event.preventDefault();
+    event.stopPropagation();
+    this.lookupCoordinatesFromCatalog();
+  }
+
+  lookupCoordinatesFromCatalog(): void {
+    const name = String(this.form.get('name')?.value ?? '').trim();
+    if (!name) {
+      this.snackBar.open('Enter an object name to look up', 'Close', { duration: 4000 });
+      this.form.get('name')?.markAsTouched();
+      return;
+    }
+    this.catalogLookupPending = true;
+    this.catalogsService.searchObjects(name, 15).pipe(
+      finalize(() => {
+        this.catalogLookupPending = false;
+      })
+    ).subscribe({
+      next: objects => {
+        if (!objects.length) {
+          this.snackBar.open(`No catalog match for "${name}"`, 'Close', { duration: 5000 });
+          return;
+        }
+        const chosen = this.pickCatalogMatch(name, objects);
+        this.form.patchValue(
+          { ra: chosen.ra, decl: chosen.decl },
+          { emitEvent: false }
+        );
+        const used =
+          this.normalizeCatalogLabel(chosen.name) === this.normalizeCatalogLabel(name) ||
+          this.catalogAltMatchesQuery(name, chosen)
+            ? chosen.name
+            : `${chosen.name} (best match for "${name}")`;
+        this.snackBar.open(`Coordinates filled from catalog: ${used}`, 'Close', { duration: 5000 });
+      },
+      error: err => {
+        const msg = err?.error?.msg || err?.message || 'Catalog lookup failed';
+        this.snackBar.open(msg, 'Close', { duration: 5000 });
+      }
+    });
+  }
+
+  get raSexagesimalHint(): string {
+    const raw = this.form.get('ra')?.value;
+    if (raw === null || raw === undefined || raw === '') {
+      return '';
+    }
+    const n = Number(raw);
+    if (Number.isNaN(n)) {
+      return '';
+    }
+    return this.coordsFormatter.formatRA(n);
+  }
+
+  get decSexagesimalHint(): string {
+    const raw = this.form.get('decl')?.value;
+    if (raw === null || raw === undefined || raw === '') {
+      return '';
+    }
+    const n = Number(raw);
+    if (Number.isNaN(n)) {
+      return '';
+    }
+    return this.coordsFormatter.formatDec(n);
+  }
+
+  private normalizeCatalogLabel(s: string): string {
+    return s.trim().toLowerCase().replace(/\s+/g, ' ');
+  }
+
+  private catalogAltMatchesQuery(query: string, o: CatalogObject): boolean {
+    const q = this.normalizeCatalogLabel(query);
+    const parts = (o.altname ?? '')
+      .split(/[,;]/)
+      .map(x => this.normalizeCatalogLabel(x))
+      .filter(Boolean);
+    return parts.includes(q);
+  }
+
+  private pickCatalogMatch(query: string, objects: CatalogObject[]): CatalogObject {
+    const q = this.normalizeCatalogLabel(query);
+    const byName = objects.find(o => this.normalizeCatalogLabel(o.name) === q);
+    if (byName) {
+      return byName;
+    }
+    const byAlt = objects.find(o => this.catalogAltMatchesQuery(query, o));
+    return byAlt ?? objects[0];
+  }
+
   save(): void {
     if (this.form.invalid) {
+      this.form.markAllAsTouched();
       return;
     }
     const value = this.form.getRawValue();
-    const ra = value.ra != null && value.ra !== '' ? Number(value.ra) : undefined;
-    const decl = value.decl != null && value.decl !== '' ? Number(value.decl) : undefined;
+    const ra = Number(value.ra);
+    const decl = Number(value.decl);
     const body = {
       name: value.name,
       scope_id: value.scope_id,
       description: value.description || undefined,
       active: value.active,
-      ...(ra != null && decl != null && !Number.isNaN(ra) && !Number.isNaN(decl) ? { ra, decl } : {})
+      ra,
+      decl
     };
     this.projectsService.createProject(body).subscribe({
       next: () => {

--- a/src/app/components/project-form-dialog/project-form-dialog.component.ts
+++ b/src/app/components/project-form-dialog/project-form-dialog.component.ts
@@ -1,5 +1,5 @@
 import { Component, inject } from '@angular/core';
-import { FormBuilder, FormGroup, ReactiveFormsModule, Validators } from '@angular/forms';
+import { AbstractControl, FormBuilder, FormGroup, ReactiveFormsModule, ValidationErrors, Validators } from '@angular/forms';
 import { MatDialogRef, MAT_DIALOG_DATA, MatDialogModule } from '@angular/material/dialog';
 import { MatFormFieldModule } from '@angular/material/form-field';
 import { MatInputModule } from '@angular/material/input';
@@ -11,6 +11,23 @@ import { MatSnackBar } from '@angular/material/snack-bar';
 import { CatalogsService, CatalogObject } from '../../services/catalogs.service';
 import { CoordsFormatterService } from '../../services/coords-formatter.service';
 import { finalize } from 'rxjs/operators';
+import { parseDecDegrees, parseRAHours } from '../../utils/coord-parse';
+
+function raFieldValidator(c: AbstractControl): ValidationErrors | null {
+  const raw = String(c.value ?? '').trim();
+  if (!raw) {
+    return null;
+  }
+  return parseRAHours(raw) === null ? { raParse: true } : null;
+}
+
+function decFieldValidator(c: AbstractControl): ValidationErrors | null {
+  const raw = String(c.value ?? '').trim();
+  if (!raw) {
+    return null;
+  }
+  return parseDecDegrees(raw) === null ? { decParse: true } : null;
+}
 
 export interface ProjectFormDialogData {
   scopes: { scope_id: number; name: string }[];
@@ -49,8 +66,8 @@ export class ProjectFormDialogComponent {
       scope_id: [null as number | null, Validators.required],
       description: [''],
       regexps: [''],
-      ra: [null as number | null, [Validators.required, Validators.min(0), Validators.max(24)]],
-      decl: [null as number | null, [Validators.required, Validators.min(-90), Validators.max(90)]],
+      ra: ['', [Validators.required, raFieldValidator]],
+      decl: ['', [Validators.required, decFieldValidator]],
       active: [true]
     });
   }
@@ -90,7 +107,7 @@ export class ProjectFormDialogComponent {
         }
         const chosen = this.pickCatalogMatch(name, objects);
         this.form.patchValue(
-          { ra: chosen.ra, decl: chosen.decl },
+          { ra: String(chosen.ra), decl: String(chosen.decl) },
           { emitEvent: false }
         );
         const used =
@@ -108,27 +125,19 @@ export class ProjectFormDialogComponent {
   }
 
   get raSexagesimalHint(): string {
-    const raw = this.form.get('ra')?.value;
-    if (raw === null || raw === undefined || raw === '') {
+    const parsed = parseRAHours(String(this.form.get('ra')?.value ?? '').trim());
+    if (parsed === null) {
       return '';
     }
-    const n = Number(raw);
-    if (Number.isNaN(n)) {
-      return '';
-    }
-    return this.coordsFormatter.formatRA(n);
+    return this.coordsFormatter.formatRA(parsed);
   }
 
   get decSexagesimalHint(): string {
-    const raw = this.form.get('decl')?.value;
-    if (raw === null || raw === undefined || raw === '') {
+    const parsed = parseDecDegrees(String(this.form.get('decl')?.value ?? '').trim());
+    if (parsed === null) {
       return '';
     }
-    const n = Number(raw);
-    if (Number.isNaN(n)) {
-      return '';
-    }
-    return this.coordsFormatter.formatDec(n);
+    return this.coordsFormatter.formatDec(parsed);
   }
 
   private normalizeCatalogLabel(s: string): string {
@@ -160,8 +169,12 @@ export class ProjectFormDialogComponent {
       return;
     }
     const value = this.form.getRawValue();
-    const ra = Number(value.ra);
-    const decl = Number(value.decl);
+    const ra = parseRAHours(String(value.ra).trim());
+    const decl = parseDecDegrees(String(value.decl).trim());
+    if (ra === null || decl === null) {
+      this.snackBar.open('Invalid RA or Dec', 'Close', { duration: 4000 });
+      return;
+    }
     const body = {
       name: value.name,
       scope_id: value.scope_id,

--- a/src/app/components/project-form-dialog/project-form-dialog.component.ts
+++ b/src/app/components/project-form-dialog/project-form-dialog.component.ts
@@ -48,6 +48,7 @@ export class ProjectFormDialogComponent {
       name: ['', Validators.required],
       scope_id: [null as number | null, Validators.required],
       description: [''],
+      regexps: [''],
       ra: [null as number | null, [Validators.required, Validators.min(0), Validators.max(24)]],
       decl: [null as number | null, [Validators.required, Validators.min(-90), Validators.max(90)]],
       active: [true]
@@ -165,6 +166,7 @@ export class ProjectFormDialogComponent {
       name: value.name,
       scope_id: value.scope_id,
       description: value.description || undefined,
+      regexps: String(value.regexps ?? '').trim(),
       active: value.active,
       ra,
       decl

--- a/src/app/components/project-form-dialog/project-form-dialog.component.ts
+++ b/src/app/components/project-form-dialog/project-form-dialog.component.ts
@@ -7,6 +7,7 @@ import { MatSelectModule } from '@angular/material/select';
 import { MatButtonModule } from '@angular/material/button';
 import { MatCheckboxModule } from '@angular/material/checkbox';
 import { ProjectsService } from '../../services/projects.service';
+import { ProjectCreate } from '../../models/project';
 import { MatSnackBar } from '@angular/material/snack-bar';
 import { CatalogsService, CatalogObject } from '../../services/catalogs.service';
 import { CoordsFormatterService } from '../../services/coords-formatter.service';
@@ -68,7 +69,9 @@ export class ProjectFormDialogComponent {
       regexps: [''],
       ra: ['', [Validators.required, raFieldValidator]],
       decl: ['', [Validators.required, decFieldValidator]],
-      active: [true]
+      active: [true],
+      start_date: [''],
+      end_date: ['']
     });
   }
 
@@ -175,14 +178,18 @@ export class ProjectFormDialogComponent {
       this.snackBar.open('Invalid RA or Dec', 'Close', { duration: 4000 });
       return;
     }
-    const body = {
+    const sd = String(value.start_date ?? '').trim().slice(0, 10);
+    const ed = String(value.end_date ?? '').trim().slice(0, 10);
+    const body: ProjectCreate = {
       name: value.name,
       scope_id: value.scope_id,
       description: value.description || undefined,
       regexps: String(value.regexps ?? '').trim(),
       active: value.active,
       ra,
-      decl
+      decl,
+      ...(sd ? { start_date: sd } : {}),
+      ...(ed ? { end_date: ed } : {})
     };
     this.projectsService.createProject(body).subscribe({
       next: () => {

--- a/src/app/components/projects-list/projects-list.component.css
+++ b/src/app/components/projects-list/projects-list.component.css
@@ -45,6 +45,17 @@ table {
   text-decoration: underline;
 }
 
+.scope-link {
+  color: var(--mat-primary-color, #1976d2);
+  text-decoration: underline;
+  font: inherit;
+  cursor: pointer;
+}
+
+.scope-link:hover {
+  text-decoration: none;
+}
+
 tr.clickable {
   cursor: pointer;
 }

--- a/src/app/components/projects-list/projects-list.component.css
+++ b/src/app/components/projects-list/projects-list.component.css
@@ -48,3 +48,10 @@ table {
 tr.clickable {
   cursor: pointer;
 }
+
+.summary-cell {
+  max-width: 280px;
+  white-space: normal;
+  word-break: break-word;
+  font-size: 0.9rem;
+}

--- a/src/app/components/projects-list/projects-list.component.html
+++ b/src/app/components/projects-list/projects-list.component.html
@@ -43,12 +43,23 @@
         <th mat-header-cell *matHeaderCellDef mat-sort-header sortActionDescription="Sort by scope">Scope</th>
         <td mat-cell *matCellDef="let p">{{ getScopeName(p.scope_id) }}</td>
       </ng-container>
+      <ng-container matColumnDef="summary">
+        <th mat-header-cell *matHeaderCellDef mat-sort-header sortActionDescription="Sort by plan summary">Plan (by filter)</th>
+        <td mat-cell *matCellDef="let p" class="summary-cell">{{ projectSummary(p) }}</td>
+      </ng-container>
+      <ng-container matColumnDef="integration">
+        <th mat-header-cell *matHeaderCellDef mat-sort-header sortActionDescription="Sort by captured integration">Captured</th>
+        <td mat-cell *matCellDef="let p" [matTooltip]="projectIntegrationTooltip(p)">
+          {{ projectCapturedLabel(p) }}
+        </td>
+      </ng-container>
       <ng-container matColumnDef="active">
         <th mat-header-cell *matHeaderCellDef mat-sort-header sortActionDescription="Sort by active">Active</th>
-        <td mat-cell *matCellDef="let p">
-          <mat-icon [style.color]="p.active ? 'green' : 'red'">
-            {{ p.active ? 'check_circle' : 'cancel' }}
-          </mat-icon>
+        <td mat-cell *matCellDef="let p" (click)="$event.stopPropagation()">
+          <mat-slide-toggle
+            [checked]="p.active"
+            (change)="toggleProjectActive(p, $event.checked)">
+          </mat-slide-toggle>
         </td>
       </ng-container>
       <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>

--- a/src/app/components/projects-list/projects-list.component.html
+++ b/src/app/components/projects-list/projects-list.component.html
@@ -19,7 +19,14 @@
   </div>
 
   <div class="table-container">
-    <table mat-table [dataSource]="dataSource" matSort (matSortChange)="onSortChange($event)" class="mat-elevation-z8">
+    <table
+      mat-table
+      [dataSource]="dataSource"
+      matSort
+      [matSortActive]="sortState.active"
+      [matSortDirection]="sortState.direction"
+      (matSortChange)="onSortChange($event)"
+      class="mat-elevation-z8">
       <ng-container matColumnDef="project_id">
         <th mat-header-cell *matHeaderCellDef mat-sort-header sortActionDescription="Sort by ID">ID</th>
         <td mat-cell *matCellDef="let p">{{ p.project_id }}</td>
@@ -36,21 +43,41 @@
         </td>
       </ng-container>
       <ng-container matColumnDef="description">
-        <th mat-header-cell *matHeaderCellDef>Description</th>
+        <th mat-header-cell *matHeaderCellDef mat-sort-header sortActionDescription="Sort by description">Description</th>
         <td mat-cell *matCellDef="let p">{{ p.description ?? '-' }}</td>
       </ng-container>
       <ng-container matColumnDef="scope_id">
-        <th mat-header-cell *matHeaderCellDef mat-sort-header sortActionDescription="Sort by scope">Scope</th>
-        <td mat-cell *matCellDef="let p">{{ getScopeName(p.scope_id) }}</td>
+        <th mat-header-cell *matHeaderCellDef mat-sort-header sortActionDescription="Sort by telescope name">Scope</th>
+        <td mat-cell *matCellDef="let p" (click)="$event.stopPropagation()">
+          <a [routerLink]="['/scopes', p.scope_id]" class="scope-link">{{ getScopeName(p.scope_id) }}</a>
+        </td>
       </ng-container>
       <ng-container matColumnDef="summary">
         <th mat-header-cell *matHeaderCellDef mat-sort-header sortActionDescription="Sort by plan summary">Plan (by filter)</th>
         <td mat-cell *matCellDef="let p" class="summary-cell">{{ projectSummary(p) }}</td>
       </ng-container>
       <ng-container matColumnDef="integration">
-        <th mat-header-cell *matHeaderCellDef mat-sort-header sortActionDescription="Sort by captured integration">Captured</th>
+        <th mat-header-cell *matHeaderCellDef mat-sort-header sortActionDescription="Sort by total integration">Integration</th>
         <td mat-cell *matCellDef="let p" [matTooltip]="projectIntegrationTooltip(p)">
-          {{ projectCapturedLabel(p) }}
+          {{ projectTotalIntegrationLabel(p) }}
+        </td>
+      </ng-container>
+      <ng-container matColumnDef="start_date">
+        <th mat-header-cell *matHeaderCellDef mat-sort-header sortActionDescription="Sort by start date">Start</th>
+        <td mat-cell *matCellDef="let p">{{ formatCalendarDate(p.start_date) }}</td>
+      </ng-container>
+      <ng-container matColumnDef="end_date">
+        <th mat-header-cell *matHeaderCellDef mat-sort-header sortActionDescription="Sort by end date">End</th>
+        <td mat-cell *matCellDef="let p">{{ formatCalendarDate(p.end_date) }}</td>
+      </ng-container>
+      <ng-container matColumnDef="last_updated">
+        <th mat-header-cell *matHeaderCellDef mat-sort-header sortActionDescription="Sort by last updated">Last updated</th>
+        <td mat-cell *matCellDef="let p">
+          @if (p.last_updated) {
+            {{ p.last_updated | date: 'medium' }}
+          } @else {
+            —
+          }
         </td>
       </ng-container>
       <ng-container matColumnDef="active">

--- a/src/app/components/projects-list/projects-list.component.spec.ts
+++ b/src/app/components/projects-list/projects-list.component.spec.ts
@@ -1,0 +1,162 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+import { provideRouter, Router } from '@angular/router';
+import { MatDialog } from '@angular/material/dialog';
+import { MatSnackBar } from '@angular/material/snack-bar';
+import { of } from 'rxjs';
+import { ProjectsListComponent } from './projects-list.component';
+import { ProjectsService } from '../../services/projects.service';
+import { Telescope, TelescopeService } from '../../services/telescope.service';
+import { TopBarService } from '../../services/top-bar.service';
+import { Project } from '../../models/project';
+
+function minimalTelescope(partial: Partial<Telescope> & Pick<Telescope, 'scope_id' | 'name' | 'active'>): Telescope {
+  return {
+    descr: '',
+    min_dec: 0,
+    max_dec: 90,
+    focal: null,
+    aperture: null,
+    lon: null,
+    lat: null,
+    alt: null,
+    sensor: null,
+    ...partial
+  };
+}
+
+describe('ProjectsListComponent', () => {
+  let fixture: ComponentFixture<ProjectsListComponent>;
+  let component: ProjectsListComponent;
+  let projectsService: { getProjects: ReturnType<typeof vi.fn>; updateProject: ReturnType<typeof vi.fn> };
+  let telescopeService: { getTelescopes: ReturnType<typeof vi.fn> };
+
+  const mockProjects: Project[] = [
+    {
+      project_id: 1,
+      name: 'Alpha',
+      scope_id: 1,
+      active: true,
+      total_integration_time: 3600,
+      start_date: '2026-01-15',
+      end_date: '2026-06-01',
+      last_updated: '2026-05-01T12:00:00.000Z'
+    },
+    {
+      project_id: 2,
+      name: 'Beta',
+      scope_id: 2,
+      active: false,
+      total_integration_time: 0,
+      last_updated: '2026-04-01T08:00:00.000Z'
+    }
+  ];
+
+  beforeEach(async () => {
+    projectsService = {
+      getProjects: vi.fn().mockReturnValue(
+        of({
+          projects: mockProjects,
+          total: 2,
+          page: 1,
+          per_page: 500,
+          pages: 1
+        })
+      ),
+      updateProject: vi.fn().mockReturnValue(of({ ...mockProjects[0], active: false }))
+    };
+    telescopeService = {
+      getTelescopes: vi.fn().mockReturnValue(
+        of([
+          minimalTelescope({ scope_id: 1, name: 'T-One', active: true }),
+          minimalTelescope({ scope_id: 2, name: 'T-Two', active: false })
+        ])
+      )
+    };
+
+    await TestBed.configureTestingModule({
+      imports: [ProjectsListComponent, NoopAnimationsModule],
+      providers: [
+        TopBarService,
+        provideRouter([]),
+        { provide: ProjectsService, useValue: projectsService },
+        { provide: TelescopeService, useValue: telescopeService },
+        { provide: MatDialog, useValue: { open: vi.fn().mockReturnValue({ afterClosed: () => of(false) }) } },
+        { provide: MatSnackBar, useValue: { open: vi.fn() } }
+      ]
+    }).compileComponents();
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(ProjectsListComponent);
+    component = fixture.componentInstance;
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('requests default server sort last_updated desc on load', async () => {
+    fixture.detectChanges();
+    await fixture.whenStable();
+    expect(projectsService.getProjects).toHaveBeenCalledWith(
+      expect.objectContaining({
+        per_page: 500,
+        sort_by: 'last_updated',
+        sort_order: 'desc'
+      })
+    );
+  });
+
+  it('filters to active projects by default', async () => {
+    fixture.detectChanges();
+    await fixture.whenStable();
+    expect(component.dataSource.data.length).toBe(1);
+    expect(component.dataSource.data[0].project_id).toBe(1);
+  });
+
+  it('shows integration from total_integration_time and scope name', async () => {
+    fixture.detectChanges();
+    await fixture.whenStable();
+    fixture.detectChanges();
+    const text = fixture.nativeElement.textContent as string;
+    expect(text).toContain('1h');
+    expect(text).toContain('T-One');
+    const scopeLink = fixture.nativeElement.querySelector('a.scope-link') as HTMLAnchorElement | null;
+    expect(scopeLink?.textContent?.trim()).toBe('T-One');
+  });
+
+  it('openProject navigates to project detail', async () => {
+    fixture.detectChanges();
+    await fixture.whenStable();
+    const router = TestBed.inject(Router);
+    const spy = vi.spyOn(router, 'navigate');
+    component.openProject(mockProjects[0]);
+    expect(spy).toHaveBeenCalledWith(['/projects', 1]);
+  });
+
+  it('reloads with sort_by name when sorting by name', async () => {
+    fixture.detectChanges();
+    await fixture.whenStable();
+    projectsService.getProjects.mockClear();
+    component.onSortChange({ active: 'name', direction: 'asc' });
+    await fixture.whenStable();
+    expect(projectsService.getProjects).toHaveBeenCalledWith(
+      expect.objectContaining({
+        sort_by: 'name',
+        sort_order: 'asc'
+      })
+    );
+  });
+
+  it('formatCalendarDate returns dash for empty', () => {
+    expect(component.formatCalendarDate(null)).toBe('—');
+    expect(component.formatCalendarDate('')).toBe('—');
+    expect(component.formatCalendarDate('2026-03-20')).toBe('2026-03-20');
+  });
+
+  it('projectTotalIntegrationLabel uses API field', () => {
+    expect(component.projectTotalIntegrationLabel(mockProjects[0])).toContain('h');
+    expect(component.projectTotalIntegrationLabel({ ...mockProjects[0], total_integration_time: null })).toBe('—');
+  });
+});

--- a/src/app/components/projects-list/projects-list.component.ts
+++ b/src/app/components/projects-list/projects-list.component.ts
@@ -1,9 +1,10 @@
 import { Component, OnInit, OnDestroy, inject } from '@angular/core';
+import { DatePipe } from '@angular/common';
 import { MatSnackBar } from '@angular/material/snack-bar';
-import { Router } from '@angular/router';
+import { Router, RouterModule } from '@angular/router';
 import { ProjectsService } from '../../services/projects.service';
 import { TelescopeService } from '../../services/telescope.service';
-import { Project } from '../../models/project';
+import { Project, ProjectsListParams } from '../../models/project';
 import { MatTableDataSource, MatTableModule } from '@angular/material/table';
 import { MatSortModule, Sort } from '@angular/material/sort';
 import { MatIconModule } from '@angular/material/icon';
@@ -18,12 +19,7 @@ import { MatDialog } from '@angular/material/dialog';
 import { trigger, state, style, transition, animate } from '@angular/animations';
 import { TopBarService } from '../../services/top-bar.service';
 import { ProjectFormDialogComponent } from '../project-form-dialog/project-form-dialog.component';
-import {
-  formatIntegrationDuration,
-  projectFilterGoalSummary,
-  projectTotalCapturedSeconds,
-  projectTotalGoalSeconds
-} from '../../utils/project-integration';
+import { formatIntegrationDuration, projectFilterGoalSummary } from '../../utils/project-integration';
 
 @Component({
   selector: 'app-projects-list',
@@ -57,7 +53,9 @@ import {
     MatFormFieldModule,
     MatIconModule,
     MatSlideToggleModule,
-    MatTooltipModule
+    MatTooltipModule,
+    RouterModule,
+    DatePipe
   ]
 })
 export class ProjectsListComponent implements OnInit, OnDestroy {
@@ -71,6 +69,9 @@ export class ProjectsListComponent implements OnInit, OnDestroy {
 
   dataSource = new MatTableDataSource<Project>();
   allProjects: Project[] = [];
+  /** All telescopes for resolving scope names and links. */
+  allScopes: { scope_id: number; name: string }[] = [];
+  /** Active telescopes only (filter dropdown). */
   scopes: { scope_id: number; name: string }[] = [];
   displayedColumns: string[] = [
     'project_id',
@@ -79,12 +80,19 @@ export class ProjectsListComponent implements OnInit, OnDestroy {
     'scope_id',
     'summary',
     'integration',
+    'start_date',
+    'end_date',
+    'last_updated',
     'active'
   ];
 
   filterForm: FormGroup;
   isFilterVisible = false;
-  sortState: { active: string; direction: 'asc' | 'desc' } = { active: 'project_id', direction: 'asc' };
+  /** Default: most recently updated first (matches GET /api/projects defaults). */
+  sortState: { active: string; direction: 'asc' | 'desc' } = {
+    active: 'last_updated',
+    direction: 'desc'
+  };
 
   constructor() {
     this.filterForm = this.fb.group({
@@ -106,6 +114,7 @@ export class ProjectsListComponent implements OnInit, OnDestroy {
   ngOnInit(): void {
     this.telescopeService.getTelescopes().subscribe({
       next: list => {
+        this.allScopes = list.map(t => ({ scope_id: t.scope_id, name: t.name }));
         this.scopes = list.filter(t => t.active).map(t => ({ scope_id: t.scope_id, name: t.name }));
       }
     });
@@ -119,33 +128,72 @@ export class ProjectsListComponent implements OnInit, OnDestroy {
     this.topBarService.resetState();
   }
 
+  /** Maps mat-sort column id to GET /api/projects `sort_by` when supported; otherwise null (client sort). */
+  private sortColumnMapsToApiField(active: string): ProjectsListParams['sort_by'] | null {
+    switch (active) {
+      case 'project_id':
+        return 'project_id';
+      case 'name':
+        return 'name';
+      case 'last_updated':
+        return 'last_updated';
+      case 'integration':
+        return 'total_integration_time';
+      case 'start_date':
+        return 'start_date';
+      case 'end_date':
+        return 'end_date';
+      default:
+        return null;
+    }
+  }
+
+  private usesClientSortOnly(): boolean {
+    return this.sortColumnMapsToApiField(this.sortState.active) === null;
+  }
+
   private loadProjects(): void {
     const scopeId = this.filterForm?.get('scope_id')?.value ?? null;
-    this.projectsService.getProjects({
-      per_page: 500,
-      ...(scopeId != null && scopeId !== '' ? { scope_id: Number(scopeId) } : {})
-    }).subscribe({
-      next: res => {
-        this.allProjects = res.projects ?? [];
-        this.applyClientFilterAndSort();
-      },
-      error: err => console.error('Error loading projects:', err)
-    });
+    const sortBy = this.sortColumnMapsToApiField(this.sortState.active);
+    const sortParams: Pick<ProjectsListParams, 'sort_by' | 'sort_order'> = sortBy
+      ? { sort_by: sortBy, sort_order: this.sortState.direction }
+      : { sort_by: 'last_updated', sort_order: 'desc' };
+    this.projectsService
+      .getProjects({
+        per_page: 500,
+        ...sortParams,
+        ...(scopeId != null && scopeId !== '' ? { scope_id: Number(scopeId) } : {})
+      })
+      .subscribe({
+        next: res => {
+          this.allProjects = res.projects ?? [];
+          this.applyClientFilterAndSort();
+        },
+        error: err => console.error('Error loading projects:', err)
+      });
   }
 
   private applyClientFilterAndSort(): void {
     const activeOnly = this.filterForm?.get('activeOnly')?.value ?? true;
     let list = activeOnly ? this.allProjects.filter(p => p.active) : this.allProjects;
-    const { active, direction } = this.sortState;
-    list = [...list].sort((a, b) => {
-      let aVal: string | number | boolean = this.sortValueForColumn(a, active);
-      let bVal: string | number | boolean = this.sortValueForColumn(b, active);
-      if (typeof aVal === 'string') aVal = aVal.toLowerCase();
-      if (typeof bVal === 'string') bVal = bVal.toLowerCase();
-      if (aVal === bVal) return 0;
-      const cmp = aVal < bVal ? -1 : 1;
-      return direction === 'asc' ? cmp : -cmp;
-    });
+    if (this.usesClientSortOnly()) {
+      const { active, direction } = this.sortState;
+      list = [...list].sort((a, b) => {
+        let aVal: string | number | boolean = this.sortValueForColumn(a, active);
+        let bVal: string | number | boolean = this.sortValueForColumn(b, active);
+        if (typeof aVal === 'string') {
+          aVal = aVal.toLowerCase();
+        }
+        if (typeof bVal === 'string') {
+          bVal = bVal.toLowerCase();
+        }
+        if (aVal === bVal) {
+          return 0;
+        }
+        const cmp = aVal < bVal ? -1 : 1;
+        return direction === 'asc' ? cmp : -cmp;
+      });
+    }
     this.dataSource.data = list;
     this.topBarService.updateState({
       title: `Projects: ${list.length} item${list.length !== 1 ? 's' : ''}`
@@ -162,11 +210,15 @@ export class ProjectsListComponent implements OnInit, OnDestroy {
   }
 
   onSortChange(sort: Sort): void {
-    this.sortState = {
-      active: sort.active || 'project_id',
-      direction: (sort.direction as 'asc' | 'desc') || 'asc'
-    };
-    this.applyClientFilterAndSort();
+    if (!sort.direction) {
+      this.sortState = { active: 'last_updated', direction: 'desc' };
+    } else {
+      this.sortState = {
+        active: sort.active || 'last_updated',
+        direction: (sort.direction as 'asc' | 'desc') || 'desc'
+      };
+    }
+    this.loadProjects();
   }
 
   toggleFilters(): void {
@@ -193,7 +245,7 @@ export class ProjectsListComponent implements OnInit, OnDestroy {
   }
 
   getScopeName(scopeId: number): string {
-    const s = this.scopes.find(x => x.scope_id === scopeId);
+    const s = this.allScopes.find(x => x.scope_id === scopeId);
     return s ? s.name : String(scopeId);
   }
 
@@ -201,8 +253,18 @@ export class ProjectsListComponent implements OnInit, OnDestroy {
     if (column === 'summary') {
       return projectFilterGoalSummary(p) || '';
     }
+    if (column === 'scope_id') {
+      return this.getScopeName(p.scope_id).toLowerCase();
+    }
     if (column === 'integration') {
-      return projectTotalCapturedSeconds(p);
+      const t = p.total_integration_time;
+      return t != null && Number.isFinite(Number(t)) ? Number(t) : -1;
+    }
+    if (column === 'active') {
+      return p.active;
+    }
+    if (column === 'description') {
+      return (p.description ?? '').toLowerCase();
     }
     return (p as unknown as Record<string, unknown>)[column] as string | number | boolean;
   }
@@ -212,22 +274,28 @@ export class ProjectsListComponent implements OnInit, OnDestroy {
     return s || '—';
   }
 
-  projectCapturedLabel(p: Project): string {
-    const subs = p.subframes ?? [];
-    if (!subs.length) {
-      return '—';
+  projectTotalIntegrationLabel(p: Project): string {
+    const t = p.total_integration_time;
+    if (t != null && Number.isFinite(Number(t))) {
+      return formatIntegrationDuration(Number(t));
     }
-    return formatIntegrationDuration(projectTotalCapturedSeconds(p));
+    return '—';
   }
 
   projectIntegrationTooltip(p: Project): string {
-    const subs = p.subframes ?? [];
-    if (!subs.length) {
-      return 'Subframes not included in list response — open project for totals';
+    const api = this.projectTotalIntegrationLabel(p);
+    const summary = projectFilterGoalSummary(p);
+    if (summary && summary !== '—') {
+      return `Total integration: ${api}. Plan (goal): ${summary}.`;
     }
-    const goal = formatIntegrationDuration(projectTotalGoalSeconds(p));
-    const cap = formatIntegrationDuration(projectTotalCapturedSeconds(p));
-    return `Captured: ${cap} · Goal total: ${goal}`;
+    return `Total integration: ${api}`;
+  }
+
+  formatCalendarDate(value: string | null | undefined): string {
+    if (value == null || String(value).trim() === '') {
+      return '—';
+    }
+    return String(value).trim().slice(0, 10);
   }
 
   toggleProjectActive(p: Project, next: boolean): void {

--- a/src/app/components/projects-list/projects-list.component.ts
+++ b/src/app/components/projects-list/projects-list.component.ts
@@ -1,4 +1,5 @@
 import { Component, OnInit, OnDestroy, inject } from '@angular/core';
+import { MatSnackBar } from '@angular/material/snack-bar';
 import { Router } from '@angular/router';
 import { ProjectsService } from '../../services/projects.service';
 import { TelescopeService } from '../../services/telescope.service';
@@ -6,6 +7,8 @@ import { Project } from '../../models/project';
 import { MatTableDataSource, MatTableModule } from '@angular/material/table';
 import { MatSortModule, Sort } from '@angular/material/sort';
 import { MatIconModule } from '@angular/material/icon';
+import { MatSlideToggleModule } from '@angular/material/slide-toggle';
+import { MatTooltipModule } from '@angular/material/tooltip';
 import { FormBuilder, FormGroup, ReactiveFormsModule } from '@angular/forms';
 import { MatCheckboxModule } from '@angular/material/checkbox';
 import { MatButtonModule } from '@angular/material/button';
@@ -15,6 +18,12 @@ import { MatDialog } from '@angular/material/dialog';
 import { trigger, state, style, transition, animate } from '@angular/animations';
 import { TopBarService } from '../../services/top-bar.service';
 import { ProjectFormDialogComponent } from '../project-form-dialog/project-form-dialog.component';
+import {
+  formatIntegrationDuration,
+  projectFilterGoalSummary,
+  projectTotalCapturedSeconds,
+  projectTotalGoalSeconds
+} from '../../utils/project-integration';
 
 @Component({
   selector: 'app-projects-list',
@@ -46,7 +55,9 @@ import { ProjectFormDialogComponent } from '../project-form-dialog/project-form-
     MatButtonModule,
     MatSelectModule,
     MatFormFieldModule,
-    MatIconModule
+    MatIconModule,
+    MatSlideToggleModule,
+    MatTooltipModule
   ]
 })
 export class ProjectsListComponent implements OnInit, OnDestroy {
@@ -56,11 +67,20 @@ export class ProjectsListComponent implements OnInit, OnDestroy {
   private topBarService = inject(TopBarService);
   private dialog = inject(MatDialog);
   private router = inject(Router);
+  private snackBar = inject(MatSnackBar);
 
   dataSource = new MatTableDataSource<Project>();
   allProjects: Project[] = [];
   scopes: { scope_id: number; name: string }[] = [];
-  displayedColumns: string[] = ['project_id', 'name', 'description', 'scope_id', 'active'];
+  displayedColumns: string[] = [
+    'project_id',
+    'name',
+    'description',
+    'scope_id',
+    'summary',
+    'integration',
+    'active'
+  ];
 
   filterForm: FormGroup;
   isFilterVisible = false;
@@ -89,6 +109,9 @@ export class ProjectsListComponent implements OnInit, OnDestroy {
         this.scopes = list.filter(t => t.active).map(t => ({ scope_id: t.scope_id, name: t.name }));
       }
     });
+    this.filterForm.get('activeOnly')?.valueChanges.subscribe(() => {
+      this.applyClientFilterAndSort();
+    });
     this.loadProjects();
   }
 
@@ -115,8 +138,8 @@ export class ProjectsListComponent implements OnInit, OnDestroy {
     let list = activeOnly ? this.allProjects.filter(p => p.active) : this.allProjects;
     const { active, direction } = this.sortState;
     list = [...list].sort((a, b) => {
-      let aVal: string | number | boolean = (a as unknown as Record<string, unknown>)[active] as string | number | boolean;
-      let bVal: string | number | boolean = (b as unknown as Record<string, unknown>)[active] as string | number | boolean;
+      let aVal: string | number | boolean = this.sortValueForColumn(a, active);
+      let bVal: string | number | boolean = this.sortValueForColumn(b, active);
       if (typeof aVal === 'string') aVal = aVal.toLowerCase();
       if (typeof bVal === 'string') bVal = bVal.toLowerCase();
       if (aVal === bVal) return 0;
@@ -172,5 +195,60 @@ export class ProjectsListComponent implements OnInit, OnDestroy {
   getScopeName(scopeId: number): string {
     const s = this.scopes.find(x => x.scope_id === scopeId);
     return s ? s.name : String(scopeId);
+  }
+
+  private sortValueForColumn(p: Project, column: string): string | number | boolean {
+    if (column === 'summary') {
+      return projectFilterGoalSummary(p) || '';
+    }
+    if (column === 'integration') {
+      return projectTotalCapturedSeconds(p);
+    }
+    return (p as unknown as Record<string, unknown>)[column] as string | number | boolean;
+  }
+
+  projectSummary(p: Project): string {
+    const s = projectFilterGoalSummary(p);
+    return s || '—';
+  }
+
+  projectCapturedLabel(p: Project): string {
+    const subs = p.subframes ?? [];
+    if (!subs.length) {
+      return '—';
+    }
+    return formatIntegrationDuration(projectTotalCapturedSeconds(p));
+  }
+
+  projectIntegrationTooltip(p: Project): string {
+    const subs = p.subframes ?? [];
+    if (!subs.length) {
+      return 'Subframes not included in list response — open project for totals';
+    }
+    const goal = formatIntegrationDuration(projectTotalGoalSeconds(p));
+    const cap = formatIntegrationDuration(projectTotalCapturedSeconds(p));
+    return `Captured: ${cap} · Goal total: ${goal}`;
+  }
+
+  toggleProjectActive(p: Project, next: boolean): void {
+    this.projectsService.updateProject(p.project_id, { active: next }).subscribe({
+      next: updated => {
+        const i = this.allProjects.findIndex(x => x.project_id === p.project_id);
+        if (i >= 0) {
+          const prev = this.allProjects[i];
+          this.allProjects[i] = {
+            ...prev,
+            ...updated,
+            subframes: updated.subframes ?? prev.subframes
+          };
+        }
+        this.applyClientFilterAndSort();
+      },
+      error: err => {
+        this.snackBar.open(err?.error?.msg || err?.message || 'Failed to update project', 'Close', {
+          duration: 5000
+        });
+      }
+    });
   }
 }

--- a/src/app/components/subframe-form-dialog/subframe-form-dialog.component.html
+++ b/src/app/components/subframe-form-dialog/subframe-form-dialog.component.html
@@ -14,6 +14,10 @@
       <input matInput type="number" formControlName="exposure_time" min="0" step="0.1">
     </mat-form-field>
     <mat-form-field appearance="outline" class="full-width">
+      <mat-label>Count</mat-label>
+      <input matInput type="number" formControlName="count" min="0">
+    </mat-form-field>
+    <mat-form-field appearance="outline" class="full-width">
       <mat-label>Goal count</mat-label>
       <input matInput type="number" formControlName="goal_count" min="0">
     </mat-form-field>

--- a/src/app/components/subframe-form-dialog/subframe-form-dialog.component.spec.ts
+++ b/src/app/components/subframe-form-dialog/subframe-form-dialog.component.spec.ts
@@ -1,0 +1,75 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { MAT_DIALOG_DATA, MatDialogRef } from '@angular/material/dialog';
+import { SubframeFormDialogComponent } from './subframe-form-dialog.component';
+
+describe('SubframeFormDialogComponent', () => {
+  let component: SubframeFormDialogComponent;
+  let fixture: ComponentFixture<SubframeFormDialogComponent>;
+  let dialogRef: { close: ReturnType<typeof vi.fn> };
+
+  beforeEach(async () => {
+    dialogRef = { close: vi.fn() };
+
+    await TestBed.configureTestingModule({
+      imports: [SubframeFormDialogComponent],
+      providers: [
+        { provide: MatDialogRef, useValue: dialogRef },
+        { provide: MAT_DIALOG_DATA, useValue: { mode: 'add', filters: [{ filter_id: 1, short_name: 'L', full_name: 'Lum', active: true }] } }
+      ]
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(SubframeFormDialogComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('defaults count to 0 for add payload when omitted', () => {
+    component.form.patchValue({
+      filter_id: 1,
+      exposure_time: 120,
+      count: '',
+      goal_count: '',
+      active: true
+    });
+
+    component.save();
+
+    expect(dialogRef.close).toHaveBeenCalledWith({
+      filter_id: 1,
+      exposure_time: 120,
+      count: 0,
+      goal_count: undefined,
+      active: true
+    });
+  });
+
+  it('initializes count to 0 when editing legacy subframe', async () => {
+    await TestBed.resetTestingModule();
+    await TestBed.configureTestingModule({
+      imports: [SubframeFormDialogComponent],
+      providers: [
+        { provide: MatDialogRef, useValue: dialogRef },
+        {
+          provide: MAT_DIALOG_DATA,
+          useValue: {
+            mode: 'edit',
+            filters: [],
+            subframe: {
+              id: 3,
+              project_id: 1,
+              filter_id: 2,
+              exposure_time: 300,
+              active: true
+            }
+          }
+        }
+      ]
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(SubframeFormDialogComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+
+    expect(component.form.get('count')?.value).toBe(0);
+  });
+});

--- a/src/app/components/subframe-form-dialog/subframe-form-dialog.component.ts
+++ b/src/app/components/subframe-form-dialog/subframe-form-dialog.component.ts
@@ -45,6 +45,7 @@ export class SubframeFormDialogComponent {
     this.form = this.fb.group({
       filter_id: [sub?.filter_id ?? null, this.mode === 'add' ? Validators.required : []],
       exposure_time: [sub?.exposure_time ?? 0, [Validators.required, Validators.min(0)]],
+      count: [sub?.count ?? 0, [Validators.min(0)]],
       goal_count: [sub?.goal_count ?? null],
       active: [sub?.active ?? true]
     });
@@ -67,6 +68,7 @@ export class SubframeFormDialogComponent {
       const payload: ProjectSubframeCreate = {
         filter_id: value.filter_id,
         exposure_time: Number(value.exposure_time),
+        count: value.count != null && value.count !== '' ? Number(value.count) : 0,
         goal_count: value.goal_count != null && value.goal_count !== '' ? Number(value.goal_count) : undefined,
         active: value.active
       };
@@ -75,6 +77,7 @@ export class SubframeFormDialogComponent {
       const payload: ProjectSubframeUpdate = {
         filter_id: value.filter_id,
         exposure_time: Number(value.exposure_time),
+        count: value.count != null && value.count !== '' ? Number(value.count) : 0,
         goal_count: value.goal_count != null && value.goal_count !== '' ? Number(value.goal_count) : undefined,
         active: value.active
       };

--- a/src/app/login/login.component.spec.ts
+++ b/src/app/login/login.component.spec.ts
@@ -98,4 +98,18 @@ describe('LoginComponent', () => {
     expect(loginService.getBackendVersion).toHaveBeenCalled();
     expect(component.backendVersion).toBe('Unresponsive');
   });
+
+  it('navigates to projects after successful login', async () => {
+    loginService.login.mockReturnValue(
+      of({ status: true, token: 'test-token', firstname: 'Ada' })
+    );
+
+    fixture.detectChanges();
+    component.loginForm.patchValue({ username: 'user', password: 'secret' });
+    component.onSubmit();
+    await fixture.whenStable();
+
+    expect(loginService.login).toHaveBeenCalledWith('user', 'secret');
+    expect(router.navigateByUrl).toHaveBeenCalledWith('/projects');
+  });
 });

--- a/src/app/login/login.component.ts
+++ b/src/app/login/login.component.ts
@@ -88,7 +88,7 @@ export class LoginComponent implements OnInit {
             next: (data: LoginResponse) =>  {
                 if (data.status === true) {
                     this.showMessage('Login successful! Welcome, ' + data.firstname);
-                    this.router.navigateByUrl('/tasks');
+                    this.router.navigateByUrl('/projects');
                 } else {
                     this.showMessage('Login incorrect.');
                 }

--- a/src/app/models/project.ts
+++ b/src/app/models/project.ts
@@ -24,6 +24,13 @@ export interface Project {
   ra?: number;
   decl?: number;
   active: boolean;
+  /** ISO 8601; maintained when subframes change (see api/openapi.yaml). */
+  last_updated?: string | null;
+  /** Total integration seconds (sum of exposure_time × count per subframe). */
+  total_integration_time?: number | null;
+  /** Optional calendar dates (YYYY-MM-DD). */
+  start_date?: string | null;
+  end_date?: string | null;
   subframes?: ProjectSubframe[];
   user_ids?: number[];
 }
@@ -36,6 +43,8 @@ export interface ProjectCreate {
   ra?: number;
   decl?: number;
   active?: boolean;
+  start_date?: string | null;
+  end_date?: string | null;
 }
 
 export interface ProjectUpdate {
@@ -46,6 +55,8 @@ export interface ProjectUpdate {
   ra?: number;
   decl?: number;
   active?: boolean;
+  start_date?: string | null;
+  end_date?: string | null;
 }
 
 export interface ProjectSubframeCreate {
@@ -71,6 +82,15 @@ export interface ProjectsListParams {
   per_page?: number;
   user_id?: number;
   scope_id?: number;
+  /** See GET /api/projects `sort_by` enum in openapi.yaml. */
+  sort_by?:
+    | 'project_id'
+    | 'name'
+    | 'last_updated'
+    | 'total_integration_time'
+    | 'start_date'
+    | 'end_date';
+  sort_order?: 'asc' | 'desc';
 }
 
 export interface ProjectsListResponse {

--- a/src/app/models/project.ts
+++ b/src/app/models/project.ts
@@ -10,6 +10,7 @@ export interface ProjectSubframe {
   filter_id: number;
   filter?: Filter;
   exposure_time: number;
+  count?: number;
   goal_count?: number;
   active: boolean;
 }
@@ -18,6 +19,7 @@ export interface Project {
   project_id: number;
   name: string;
   description?: string;
+  regexps?: string;
   scope_id: number;
   ra?: number;
   decl?: number;
@@ -30,6 +32,7 @@ export interface ProjectCreate {
   name: string;
   scope_id: number;
   description?: string;
+  regexps?: string;
   ra?: number;
   decl?: number;
   active?: boolean;
@@ -38,6 +41,7 @@ export interface ProjectCreate {
 export interface ProjectUpdate {
   name?: string;
   description?: string;
+  regexps?: string;
   scope_id?: number;
   ra?: number;
   decl?: number;
@@ -48,6 +52,7 @@ export interface ProjectSubframeCreate {
   filter?: string;
   filter_id?: number;
   exposure_time: number;
+  count?: number;
   goal_count?: number;
   active?: boolean;
 }
@@ -56,6 +61,7 @@ export interface ProjectSubframeUpdate {
   filter?: string;
   filter_id?: number;
   exposure_time?: number;
+  count?: number;
   goal_count?: number;
   active?: boolean;
 }

--- a/src/app/services/projects.service.spec.ts
+++ b/src/app/services/projects.service.spec.ts
@@ -37,6 +37,15 @@ describe('ProjectsService', () => {
     });
   });
 
+  it('should pass sort_by and sort_order when provided', () => {
+    service.getProjects({ sort_by: 'last_updated', sort_order: 'desc', per_page: 100 }).subscribe();
+    const req = httpMock.expectOne(r => r.url.startsWith(`${Hevelius.apiUrl}/projects`));
+    expect(req.request.params.get('sort_by')).toBe('last_updated');
+    expect(req.request.params.get('sort_order')).toBe('desc');
+    expect(req.request.params.get('per_page')).toBe('100');
+    req.flush({ projects: [], total: 0, page: 1, per_page: 100, pages: 0 });
+  });
+
   it('should create project with regexps', () => {
     service.createProject({ name: 'M42', scope_id: 3, active: true, regexps: 'M.* NGC.*' }).subscribe(result => {
       expect(result.project_id).toBe(11);

--- a/src/app/services/projects.service.spec.ts
+++ b/src/app/services/projects.service.spec.ts
@@ -37,15 +37,15 @@ describe('ProjectsService', () => {
     });
   });
 
-  it('should create project', () => {
-    service.createProject({ name: 'M42', scope_id: 3, active: true }).subscribe(result => {
+  it('should create project with regexps', () => {
+    service.createProject({ name: 'M42', scope_id: 3, active: true, regexps: 'M.* NGC.*' }).subscribe(result => {
       expect(result.project_id).toBe(11);
       expect(result.project.name).toBe('M42');
     });
 
     const req = httpMock.expectOne(`${Hevelius.apiUrl}/projects`);
     expect(req.request.method).toBe('POST');
-    expect(req.request.body).toEqual({ name: 'M42', scope_id: 3, active: true });
+    expect(req.request.body).toEqual({ name: 'M42', scope_id: 3, active: true, regexps: 'M.* NGC.*' });
     req.flush({
       status: true,
       project_id: 11,
@@ -73,13 +73,13 @@ describe('ProjectsService', () => {
   });
 
   it('should add subframe and map subframe_id', () => {
-    service.addSubframe(11, { filter_id: 2, exposure_time: 120 }).subscribe(result => {
+    service.addSubframe(11, { filter_id: 2, exposure_time: 120, count: 0 }).subscribe(result => {
       expect(result.subframe_id).toBe(44);
     });
 
     const req = httpMock.expectOne(`${Hevelius.apiUrl}/projects/11/subframes`);
     expect(req.request.method).toBe('POST');
-    expect(req.request.body).toEqual({ filter_id: 2, exposure_time: 120 });
+    expect(req.request.body).toEqual({ filter_id: 2, exposure_time: 120, count: 0 });
     req.flush({ status: true, subframe_id: 44 });
   });
 });

--- a/src/app/services/projects.service.ts
+++ b/src/app/services/projects.service.ts
@@ -54,6 +54,12 @@ export class ProjectsService {
       if (params.scope_id != null) {
         httpParams = httpParams.set('scope_id', String(params.scope_id));
       }
+      if (params.sort_by != null) {
+        httpParams = httpParams.set('sort_by', params.sort_by);
+      }
+      if (params.sort_order != null) {
+        httpParams = httpParams.set('sort_order', params.sort_order);
+      }
     }
     return this.http.get<ProjectsListResponse>(this.apiUrl, { params: httpParams });
   }

--- a/src/app/utils/coord-parse.spec.ts
+++ b/src/app/utils/coord-parse.spec.ts
@@ -1,0 +1,40 @@
+import { parseDecDegrees, parseRAHours } from './coord-parse';
+
+describe('coord-parse', () => {
+  describe('parseRAHours', () => {
+    it('parses decimal hours', () => {
+      expect(parseRAHours('0.712')).toBeCloseTo(0.712, 6);
+      expect(parseRAHours('12')).toBe(12);
+    });
+
+    it('parses colon sexagesimal', () => {
+      expect(parseRAHours('12:30:00')).toBeCloseTo(12.5, 6);
+      expect(parseRAHours('00:42:43.2')).toBeCloseTo(0.711999, 4);
+    });
+
+    it('parses h/m/s suffix form', () => {
+      expect(parseRAHours('02h30m00s')).toBeCloseTo(2.5, 6);
+    });
+
+    it('rejects out-of-range RA', () => {
+      expect(parseRAHours('25')).toBeNull();
+      expect(parseRAHours('')).toBeNull();
+    });
+  });
+
+  describe('parseDecDegrees', () => {
+    it('parses decimal degrees with sign', () => {
+      expect(parseDecDegrees('+41.27')).toBeCloseTo(41.27, 4);
+      expect(parseDecDegrees('-12.5')).toBeCloseTo(-12.5, 4);
+    });
+
+    it('parses sexagesimal with sign', () => {
+      expect(parseDecDegrees('+41:16:12')).toBeCloseTo(41.27, 2);
+    });
+
+    it('rejects out-of-range Dec', () => {
+      expect(parseDecDegrees('91')).toBeNull();
+      expect(parseDecDegrees('')).toBeNull();
+    });
+  });
+});

--- a/src/app/utils/coord-parse.ts
+++ b/src/app/utils/coord-parse.ts
@@ -1,0 +1,116 @@
+/**
+ * Parse RA (decimal hours 0–24) and Dec (decimal degrees −90…90) from user input:
+ * plain floats or sexagesimal (H:M:S, Hh Mm Ss, D°M′S″, etc.).
+ */
+
+function finiteInRange(v: number, min: number, max: number): number | null {
+  if (!Number.isFinite(v)) {
+    return null;
+  }
+  if (v < min || v > max) {
+    return null;
+  }
+  return v;
+}
+
+/** Normalize HMS-style separators to colons for splitting. */
+function normalizeRaSeparators(s: string): string {
+  return s
+    .replace(/\s+/g, ' ')
+    .replace(/[hH]/g, ':')
+    .replace(/[mM]/g, ':')
+    .replace(/[sS]/g, '');
+}
+
+function parseHmsToUnit(h: number, m: number, sec: number, maxUnit: number): number | null {
+  if (![h, m, sec].every(Number.isFinite)) {
+    return null;
+  }
+  if (m < 0 || m >= 60 || sec < 0 || sec >= 60) {
+    return null;
+  }
+  const v = h + m / 60 + sec / 3600;
+  return finiteInRange(v, 0, maxUnit);
+}
+
+/**
+ * Parse right ascension to decimal hours (0–24).
+ */
+export function parseRAHours(raw: string): number | null {
+  const s = raw.trim();
+  if (!s) {
+    return null;
+  }
+
+  const strictDec = /^[+-]?(?:\d+(?:\.\d*)?|\.\d+)$/;
+  if (strictDec.test(s)) {
+    const v = parseFloat(s);
+    return finiteInRange(v, 0, 24);
+  }
+
+  const norm = normalizeRaSeparators(s).replace(/\s+/g, ':');
+  const parts = norm
+    .split(':')
+    .map(p => p.trim())
+    .filter(p => p.length > 0);
+  if (parts.length === 0) {
+    return null;
+  }
+  const h = parseFloat(parts[0]);
+  const m = parts.length >= 2 ? parseFloat(parts[1]) : 0;
+  const sec = parts.length >= 3 ? parseFloat(parts[2]) : 0;
+  if (!Number.isFinite(h) || !Number.isFinite(m) || !Number.isFinite(sec)) {
+    return null;
+  }
+  return parseHmsToUnit(h, m, sec, 24);
+}
+
+function normalizeDecSeparators(s: string): string {
+  return s
+    .replace(/\s+/g, ' ')
+    .replace(/°|deg/gi, ':')
+    .replace(/['′]/g, ':')
+    .replace(/["″]/g, '');
+}
+
+/**
+ * Parse declination to decimal degrees (−90…90).
+ */
+export function parseDecDegrees(raw: string): number | null {
+  let s = raw.trim();
+  if (!s) {
+    return null;
+  }
+
+  let sign = 1;
+  if (s[0] === '+' || s[0] === '-') {
+    sign = s[0] === '-' ? -1 : 1;
+    s = s.slice(1).trim();
+  }
+
+  const strictDec = /^(?:\d+(?:\.\d*)?|\.\d+)$/;
+  if (strictDec.test(s)) {
+    const v = sign * parseFloat(s);
+    return finiteInRange(v, -90, 90);
+  }
+
+  const norm = normalizeDecSeparators(s).replace(/\s+/g, ':');
+  const parts = norm
+    .split(':')
+    .map(p => p.trim())
+    .filter(p => p.length > 0);
+  if (parts.length === 0) {
+    return null;
+  }
+  const deg = parseFloat(parts[0]);
+  const m = parts.length >= 2 ? parseFloat(parts[1]) : 0;
+  const sec = parts.length >= 3 ? parseFloat(parts[2]) : 0;
+  if (!Number.isFinite(deg) || !Number.isFinite(m) || !Number.isFinite(sec)) {
+    return null;
+  }
+  if (m < 0 || m >= 60 || sec < 0 || sec >= 60) {
+    return null;
+  }
+  const v = sign * (Math.abs(deg) + m / 60 + sec / 3600);
+  return finiteInRange(v, -90, 90);
+}

--- a/src/app/utils/project-integration.spec.ts
+++ b/src/app/utils/project-integration.spec.ts
@@ -1,0 +1,71 @@
+import { Project, ProjectSubframe } from '../models/project';
+import {
+  formatIntegrationDuration,
+  projectTotalCapturedSeconds,
+  subframeCapturedSeconds,
+  subframeProgressPercent
+} from './project-integration';
+
+describe('project-integration', () => {
+  it('subframeCapturedSeconds multiplies count by exposure', () => {
+    const sub: ProjectSubframe = {
+      id: 1,
+      project_id: 1,
+      filter_id: 1,
+      exposure_time: 120,
+      count: 10,
+      goal_count: 20,
+      active: true
+    };
+    expect(subframeCapturedSeconds(sub)).toBe(1200);
+  });
+
+  it('projectTotalCapturedSeconds sums subframes', () => {
+    const project: Project = {
+      project_id: 1,
+      name: 'P',
+      scope_id: 1,
+      active: true,
+      subframes: [
+        {
+          id: 1,
+          project_id: 1,
+          filter_id: 1,
+          exposure_time: 60,
+          count: 2,
+          goal_count: 10,
+          active: true
+        },
+        {
+          id: 2,
+          project_id: 1,
+          filter_id: 2,
+          exposure_time: 30,
+          count: 1,
+          goal_count: 5,
+          active: true
+        }
+      ]
+    };
+    expect(projectTotalCapturedSeconds(project)).toBe(60 * 2 + 30);
+  });
+
+  it('formatIntegrationDuration formats seconds', () => {
+    expect(formatIntegrationDuration(3600)).toContain('1h');
+    expect(formatIntegrationDuration(2700)).toContain('45min');
+  });
+
+  it('subframeProgressPercent uses count and goal_count', () => {
+    const sub: ProjectSubframe = {
+      id: 1,
+      project_id: 1,
+      filter_id: 1,
+      exposure_time: 10,
+      count: 5,
+      goal_count: 10,
+      active: true
+    };
+    expect(subframeProgressPercent(sub)).toBe(50);
+    expect(subframeProgressPercent({ ...sub, goal_count: 0 })).toBeNull();
+  });
+});

--- a/src/app/utils/project-integration.ts
+++ b/src/app/utils/project-integration.ts
@@ -1,0 +1,87 @@
+import { Project, ProjectSubframe } from '../models/project';
+
+export function subframeCapturedSeconds(sub: ProjectSubframe): number {
+  const c = sub.count ?? 0;
+  const exp = sub.exposure_time ?? 0;
+  return Math.max(0, c * exp);
+}
+
+export function subframeGoalSeconds(sub: ProjectSubframe): number {
+  const g = sub.goal_count ?? 0;
+  const exp = sub.exposure_time ?? 0;
+  return Math.max(0, g * exp);
+}
+
+export function projectTotalCapturedSeconds(project: Project): number {
+  const subs = project.subframes ?? [];
+  return subs.reduce((acc, s) => acc + subframeCapturedSeconds(s), 0);
+}
+
+export function projectTotalGoalSeconds(project: Project): number {
+  const subs = project.subframes ?? [];
+  return subs.reduce((acc, s) => acc + subframeGoalSeconds(s), 0);
+}
+
+/** Human-readable duration, e.g. "8h40min", "45min", "30s". */
+export function formatIntegrationDuration(totalSeconds: number): string {
+  if (!Number.isFinite(totalSeconds) || totalSeconds <= 0) {
+    return '0min';
+  }
+  let sec = Math.round(totalSeconds);
+  const h = Math.floor(sec / 3600);
+  sec -= h * 3600;
+  const m = Math.floor(sec / 60);
+  const s = sec % 60;
+  const parts: string[] = [];
+  if (h > 0) {
+    parts.push(`${h}h`);
+  }
+  if (m > 0) {
+    parts.push(`${m}min`);
+  }
+  if (s > 0 && h === 0 && m === 0) {
+    parts.push(`${s}s`);
+  } else if (s > 0 && (h > 0 || m > 0)) {
+    parts.push(`${s}s`);
+  }
+  if (!parts.length) {
+    return '0min';
+  }
+  return parts.join('');
+}
+
+/**
+ * Brief per-filter goal summary, e.g. "Ha 8h40min, OIII 2h15min".
+ */
+export function projectFilterGoalSummary(project: Project): string {
+  const subs = project.subframes ?? [];
+  if (!subs.length) {
+    return '';
+  }
+  const byFilter = new Map<string, number>();
+  for (const s of subs) {
+    const name = (s.filter?.short_name ?? `id${s.filter_id}`).trim() || '?';
+    byFilter.set(name, (byFilter.get(name) ?? 0) + subframeGoalSeconds(s));
+  }
+  const chunks: string[] = [];
+  for (const [name, sec] of byFilter) {
+    chunks.push(`${name} ${formatIntegrationDuration(sec)}`);
+  }
+  return chunks.join(', ');
+}
+
+export function subframeProgressPercent(sub: ProjectSubframe): number | null {
+  const goal = sub.goal_count;
+  if (goal == null || goal <= 0) {
+    return null;
+  }
+  const c = sub.count ?? 0;
+  return (c / goal) * 100;
+}
+
+export function progressBarPercent(percent: number | null): number {
+  if (percent == null || !Number.isFinite(percent)) {
+    return 0;
+  }
+  return Math.min(100, Math.max(0, percent));
+}

--- a/tools/hevelius-deploy-builder/builders.json
+++ b/tools/hevelius-deploy-builder/builders.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema",
+  "builders": {
+    "deploy": {
+      "implementation": "./src/deploy",
+      "schema": "./src/schema.json",
+      "description": "Run Hevelius deploy script."
+    }
+  }
+}

--- a/tools/hevelius-deploy-builder/package.json
+++ b/tools/hevelius-deploy-builder/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "hevelius-deploy-builder",
+  "version": "0.0.1",
+  "private": true,
+  "builders": "builders.json",
+  "dependencies": {
+    "@angular-devkit/architect": "^0.2102.4"
+  }
+}

--- a/tools/hevelius-deploy-builder/src/deploy.js
+++ b/tools/hevelius-deploy-builder/src/deploy.js
@@ -1,0 +1,25 @@
+const { createBuilder } = require('@angular-devkit/architect');
+const { spawn } = require('child_process');
+const path = require('path');
+
+module.exports = createBuilder((options, context) => {
+  return new Promise((resolve) => {
+    const scriptPath = path.resolve(context.workspaceRoot, options.script);
+    context.logger.info(`Running deploy script: ${scriptPath}`);
+
+    const child = spawn(process.execPath, [scriptPath], {
+      cwd: context.workspaceRoot,
+      stdio: 'inherit',
+      env: process.env,
+    });
+
+    child.on('close', (code) => {
+      resolve({ success: code === 0 });
+    });
+
+    child.on('error', (error) => {
+      context.logger.error(error.message);
+      resolve({ success: false, error: error.message });
+    });
+  });
+});

--- a/tools/hevelius-deploy-builder/src/deploy.js
+++ b/tools/hevelius-deploy-builder/src/deploy.js
@@ -5,9 +5,10 @@ const path = require('path');
 module.exports = createBuilder((options, context) => {
   return new Promise((resolve) => {
     const scriptPath = path.resolve(context.workspaceRoot, options.script);
-    context.logger.info(`Running deploy script: ${scriptPath}`);
+    const extraArgs = Array.isArray(options.args) ? options.args : [];
+    context.logger.info(`Running script: ${scriptPath}${extraArgs.length ? ` ${extraArgs.join(' ')}` : ''}`);
 
-    const child = spawn(process.execPath, [scriptPath], {
+    const child = spawn(process.execPath, [scriptPath, ...extraArgs], {
       cwd: context.workspaceRoot,
       stdio: 'inherit',
       env: process.env,

--- a/tools/hevelius-deploy-builder/src/schema.json
+++ b/tools/hevelius-deploy-builder/src/schema.json
@@ -1,0 +1,13 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema",
+  "title": "Hevelius Deploy Builder Schema",
+  "type": "object",
+  "properties": {
+    "script": {
+      "type": "string",
+      "description": "Path to deploy script relative to workspace root",
+      "default": "scripts/deploy.js"
+    }
+  },
+  "required": ["script"]
+}

--- a/tools/hevelius-deploy-builder/src/schema.json
+++ b/tools/hevelius-deploy-builder/src/schema.json
@@ -5,8 +5,13 @@
   "properties": {
     "script": {
       "type": "string",
-      "description": "Path to deploy script relative to workspace root",
+      "description": "Path to Node script relative to workspace root",
       "default": "scripts/deploy.js"
+    },
+    "args": {
+      "type": "array",
+      "items": { "type": "string" },
+      "description": "Extra arguments passed to the script (e.g. backend branch name for sync-openapi)"
     }
   },
   "required": ["script"]


### PR DESCRIPTION
Couple project tweaks:

- [x] The target name is looked up in the catalog. If found, RA/DEC coords are set
- [x] be able to specify RA/DEC in sexagesimal format, when adding/editing
- [x] it's not possible to disable/enable a project
- [x] show count and goal, total exposure time for each subframe
- [x] show "progress bar" towards the goal for subframes
- [x] show brief summary (e.g. Ha 8h40min) on the projects list
- [x] add last updated column
- [x] add total integration time
- [x] make the projects list sortable (by name, by scope, by total integration time, by last updated)
- [x] projects should be the default landing page after login