### PR TITLE
Improve projects list on mobile/small screens

### DIFF
--- a/src/app/components/layout/layout.component.css
+++ b/src/app/components/layout/layout.component.css
@@ -10,7 +10,7 @@ mat-toolbar {
 }
 
 .content {
-  padding: 20px;
+  padding: 0;
 }
 
 .avatar-icon {

--- a/src/app/components/projects-list/projects-list.component.css
+++ b/src/app/components/projects-list/projects-list.component.css
@@ -74,3 +74,32 @@ tr.clickable {
   word-break: break-word;
   font-size: 0.9rem;
 }
+
+@media (max-width: 640px) {
+  .container {
+    padding: 6px 4px;
+  }
+
+  .filters {
+    margin-bottom: 0.5rem;
+  }
+
+  .table-container {
+    margin-top: 0.5rem;
+    overflow-x: hidden;
+  }
+
+  table {
+    font-size: 0.8rem;
+  }
+
+  /* Tighten cell padding on mobile */
+  .mat-mdc-header-cell,
+  .mat-mdc-cell {
+    padding: 4px 6px !important;
+  }
+
+  .project-link-button {
+    font-size: 0.8rem;
+  }
+}

--- a/src/app/components/projects-list/projects-list.component.css
+++ b/src/app/components/projects-list/projects-list.component.css
@@ -2,6 +2,72 @@
   padding: 20px;
 }
 
+.search-bar {
+  margin-bottom: 0.5rem;
+}
+
+.search-field {
+  width: 100%;
+  max-width: 400px;
+}
+
+.mobile-cards {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  margin-top: 0.5rem;
+}
+
+.project-card {
+  background: #fff;
+  border: 1px solid #e0e0e0;
+  border-radius: 6px;
+  padding: 12px 14px;
+  cursor: pointer;
+  transition: background 0.15s;
+}
+
+.project-card:active {
+  background: #f5f5f5;
+}
+
+.card-name {
+  font-weight: 500;
+  color: var(--mat-primary-color, #1976d2);
+  font-size: 1rem;
+  margin-bottom: 4px;
+}
+
+.card-meta {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  font-size: 0.85rem;
+  color: #555;
+}
+
+.card-integration {
+  font-size: 0.8rem;
+  color: #757575;
+  white-space: nowrap;
+  margin-left: 8px;
+}
+
+.card-description {
+  margin-top: 4px;
+  font-size: 0.8rem;
+  color: #757575;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.no-results {
+  padding: 24px;
+  text-align: center;
+  color: #757575;
+}
+
 .projects-embedded-container {
   padding: 0;
 }

--- a/src/app/components/projects-list/projects-list.component.css
+++ b/src/app/components/projects-list/projects-list.component.css
@@ -31,26 +31,29 @@
   background: #f5f5f5;
 }
 
+.card-line1 {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: 8px;
+}
+
 .card-name {
   font-weight: 500;
   color: var(--mat-primary-color, #1976d2);
   font-size: 1rem;
-  margin-bottom: 4px;
 }
 
-.card-meta {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
+.card-scope {
+  font-size: 0.8rem;
+  white-space: nowrap;
+  flex-shrink: 0;
+}
+
+.card-line2 {
+  margin-top: 3px;
   font-size: 0.85rem;
   color: #555;
-}
-
-.card-integration {
-  font-size: 0.8rem;
-  color: #757575;
-  white-space: nowrap;
-  margin-left: 8px;
 }
 
 .card-description {

--- a/src/app/components/projects-list/projects-list.component.css
+++ b/src/app/components/projects-list/projects-list.component.css
@@ -1,5 +1,5 @@
 .container {
-  padding: 20px;
+  padding: 8px;
 }
 
 .search-bar {
@@ -146,7 +146,7 @@ tr.clickable {
 
 @media (max-width: 640px) {
   .container {
-    padding: 6px 4px;
+    padding: 4px;
   }
 
   .filters {

--- a/src/app/components/projects-list/projects-list.component.html
+++ b/src/app/components/projects-list/projects-list.component.html
@@ -1,4 +1,11 @@
 <div class="container" [class.projects-embedded-container]="embedded()">
+  <div class="search-bar">
+    <mat-form-field class="search-field" subscriptSizing="dynamic" appearance="outline">
+      <mat-label>Search projects</mat-label>
+      <input matInput [formControl]="searchControl" placeholder="Filter by name…">
+    </mat-form-field>
+  </div>
+
   @if (embedded() && scopeId() !== null) {
     <div class="filters filters-embedded">
       <form [formGroup]="filterForm" class="filter-form">
@@ -30,66 +37,85 @@
     </div>
   }
 
-  <div class="table-container">
-    <table
-      mat-table
-      [dataSource]="dataSource"
-      matSort
-      [matSortActive]="sortState.active"
-      [matSortDirection]="sortState.direction"
-      (matSortChange)="onSortChange($event)"
-      class="mat-elevation-z8">
-      <ng-container matColumnDef="name">
-        <th mat-header-cell *matHeaderCellDef mat-sort-header sortActionDescription="Sort by name">Name</th>
-        <td mat-cell *matCellDef="let p">
-          <button
-            type="button"
-            class="project-link-button"
-            (click)="openProject(p)">
-            {{ p.name }}
-          </button>
-        </td>
-      </ng-container>
-      <ng-container matColumnDef="description">
-        <th mat-header-cell *matHeaderCellDef mat-sort-header sortActionDescription="Sort by description">Description</th>
-        <td mat-cell *matCellDef="let p">{{ formatDescription(p.description) }}</td>
-      </ng-container>
-      <ng-container matColumnDef="scope_id">
-        <th mat-header-cell *matHeaderCellDef mat-sort-header sortActionDescription="Sort by telescope name">Scope</th>
-        <td mat-cell *matCellDef="let p" (click)="$event.stopPropagation()">
-          <a [routerLink]="['/scopes', p.scope_id]" class="scope-link">{{ getScopeName(p.scope_id) }}</a>
-        </td>
-      </ng-container>
-      <ng-container matColumnDef="summary">
-        <th mat-header-cell *matHeaderCellDef mat-sort-header sortActionDescription="Sort by plan summary">Plan (by filter)</th>
-        <td mat-cell *matCellDef="let p" class="summary-cell">{{ projectSummary(p) }}</td>
-      </ng-container>
-      <ng-container matColumnDef="integration">
-        <th mat-header-cell *matHeaderCellDef mat-sort-header sortActionDescription="Sort by total integration">Integration</th>
-        <td mat-cell *matCellDef="let p" [matTooltip]="projectIntegrationTooltip(p)">
-          {{ projectTotalIntegrationLabel(p) }}
-        </td>
-      </ng-container>
-      <ng-container matColumnDef="start_date">
-        <th mat-header-cell *matHeaderCellDef mat-sort-header sortActionDescription="Sort by start date">Start</th>
-        <td mat-cell *matCellDef="let p">{{ formatCalendarDate(p.start_date) }}</td>
-      </ng-container>
-      <ng-container matColumnDef="end_date">
-        <th mat-header-cell *matHeaderCellDef mat-sort-header sortActionDescription="Sort by end date">End</th>
-        <td mat-cell *matCellDef="let p">{{ formatCalendarDate(p.end_date) }}</td>
-      </ng-container>
-      <ng-container matColumnDef="last_updated">
-        <th mat-header-cell *matHeaderCellDef mat-sort-header sortActionDescription="Sort by last updated">Last updated</th>
-        <td mat-cell *matCellDef="let p">
-          @if (p.last_updated) {
-            {{ p.last_updated | date: 'medium' }}
-          } @else {
-            —
+  @if (isMobile) {
+    <div class="mobile-cards">
+      @for (p of dataSource.data; track p.project_id) {
+        <div class="project-card" (click)="openProject(p)">
+          <div class="card-name">{{ p.name }}</div>
+          <div class="card-meta">
+            <a [routerLink]="['/scopes', p.scope_id]" (click)="$event.stopPropagation()" class="scope-link">{{ getScopeName(p.scope_id) }}</a>
+            <span class="card-integration">{{ projectTotalIntegrationLabel(p) }}</span>
+          </div>
+          @if (p.description) {
+            <div class="card-description">{{ p.description }}</div>
           }
-        </td>
-      </ng-container>
-      <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>
-      <tr mat-row *matRowDef="let row; columns: displayedColumns;" (dblclick)="openProject(row)" class="clickable"></tr>
-    </table>
-  </div>
+        </div>
+      } @empty {
+        <div class="no-results">No projects found.</div>
+      }
+    </div>
+  } @else {
+    <div class="table-container">
+      <table
+        mat-table
+        [dataSource]="dataSource"
+        matSort
+        [matSortActive]="sortState.active"
+        [matSortDirection]="sortState.direction"
+        (matSortChange)="onSortChange($event)"
+        class="mat-elevation-z8">
+        <ng-container matColumnDef="name">
+          <th mat-header-cell *matHeaderCellDef mat-sort-header sortActionDescription="Sort by name">Name</th>
+          <td mat-cell *matCellDef="let p">
+            <button
+              type="button"
+              class="project-link-button"
+              (click)="openProject(p)">
+              {{ p.name }}
+            </button>
+          </td>
+        </ng-container>
+        <ng-container matColumnDef="description">
+          <th mat-header-cell *matHeaderCellDef mat-sort-header sortActionDescription="Sort by description">Description</th>
+          <td mat-cell *matCellDef="let p">{{ formatDescription(p.description) }}</td>
+        </ng-container>
+        <ng-container matColumnDef="scope_id">
+          <th mat-header-cell *matHeaderCellDef mat-sort-header sortActionDescription="Sort by telescope name">Scope</th>
+          <td mat-cell *matCellDef="let p" (click)="$event.stopPropagation()">
+            <a [routerLink]="['/scopes', p.scope_id]" class="scope-link">{{ getScopeName(p.scope_id) }}</a>
+          </td>
+        </ng-container>
+        <ng-container matColumnDef="summary">
+          <th mat-header-cell *matHeaderCellDef mat-sort-header sortActionDescription="Sort by plan summary">Plan (by filter)</th>
+          <td mat-cell *matCellDef="let p" class="summary-cell">{{ projectSummary(p) }}</td>
+        </ng-container>
+        <ng-container matColumnDef="integration">
+          <th mat-header-cell *matHeaderCellDef mat-sort-header sortActionDescription="Sort by total integration">Integration</th>
+          <td mat-cell *matCellDef="let p" [matTooltip]="projectIntegrationTooltip(p)">
+            {{ projectTotalIntegrationLabel(p) }}
+          </td>
+        </ng-container>
+        <ng-container matColumnDef="start_date">
+          <th mat-header-cell *matHeaderCellDef mat-sort-header sortActionDescription="Sort by start date">Start</th>
+          <td mat-cell *matCellDef="let p">{{ formatCalendarDate(p.start_date) }}</td>
+        </ng-container>
+        <ng-container matColumnDef="end_date">
+          <th mat-header-cell *matHeaderCellDef mat-sort-header sortActionDescription="Sort by end date">End</th>
+          <td mat-cell *matCellDef="let p">{{ formatCalendarDate(p.end_date) }}</td>
+        </ng-container>
+        <ng-container matColumnDef="last_updated">
+          <th mat-header-cell *matHeaderCellDef mat-sort-header sortActionDescription="Sort by last updated">Last updated</th>
+          <td mat-cell *matCellDef="let p">
+            @if (p.last_updated) {
+              {{ p.last_updated | date: 'medium' }}
+            } @else {
+              —
+            }
+          </td>
+        </ng-container>
+        <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>
+        <tr mat-row *matRowDef="let row; columns: displayedColumns;" (dblclick)="openProject(row)" class="clickable"></tr>
+      </table>
+    </div>
+  }
 </div>

--- a/src/app/components/projects-list/projects-list.component.html
+++ b/src/app/components/projects-list/projects-list.component.html
@@ -41,10 +41,12 @@
     <div class="mobile-cards">
       @for (p of dataSource.data; track p.project_id) {
         <div class="project-card" (click)="openProject(p)">
-          <div class="card-name">{{ p.name }}</div>
-          <div class="card-meta">
-            <a [routerLink]="['/scopes', p.scope_id]" (click)="$event.stopPropagation()" class="scope-link">{{ getScopeName(p.scope_id) }}</a>
-            <span class="card-integration">{{ projectTotalIntegrationLabel(p) }}</span>
+          <div class="card-line1">
+            <span class="card-name">{{ p.name }}</span>
+            <a [routerLink]="['/scopes', p.scope_id]" (click)="$event.stopPropagation()" class="scope-link card-scope">{{ getScopeName(p.scope_id) }}</a>
+          </div>
+          <div class="card-line2">
+            {{ projectTotalIntegrationLabel(p) }}@if (projectSummary(p) !== '—') { ({{ projectSummary(p) }})}
           </div>
           @if (p.description) {
             <div class="card-description">{{ p.description }}</div>

--- a/src/app/components/projects-list/projects-list.component.html
+++ b/src/app/components/projects-list/projects-list.component.html
@@ -40,7 +40,7 @@
   @if (isMobile) {
     <div class="mobile-cards">
       @for (p of dataSource.data; track p.project_id) {
-        <div class="project-card" (click)="openProject(p)">
+        <div class="project-card" (click)="openProject(p)" (keyup.enter)="openProject(p)" tabindex="0" role="button">
           <div class="card-line1">
             <span class="card-name">{{ p.name }}</span>
             <a [routerLink]="['/scopes', p.scope_id]" (click)="$event.stopPropagation()" class="scope-link card-scope">{{ getScopeName(p.scope_id) }}</a>

--- a/src/app/components/projects-list/projects-list.component.ts
+++ b/src/app/components/projects-list/projects-list.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit, OnDestroy, inject, input, effect, untracked } from '@angular/core';
+import { Component, OnInit, OnDestroy, inject, input, effect, untracked, HostListener } from '@angular/core';
 import { DatePipe } from '@angular/common';
 import { Router, RouterModule } from '@angular/router';
 import { ProjectsService } from '../../services/projects.service';
@@ -72,16 +72,21 @@ export class ProjectsListComponent implements OnInit, OnDestroy {
   allScopes: { scope_id: number; name: string }[] = [];
   /** Active telescopes only (filter dropdown). */
   scopes: { scope_id: number; name: string }[] = [];
-  displayedColumns: string[] = [
-    'name',
-    'description',
-    'scope_id',
-    'summary',
-    'integration',
-    'start_date',
-    'end_date',
-    'last_updated'
-  ];
+
+  private readonly MOBILE_BREAKPOINT = 640;
+  isMobile = typeof window !== 'undefined' && window.innerWidth <= this.MOBILE_BREAKPOINT;
+
+  get displayedColumns(): string[] {
+    if (this.isMobile) {
+      return ['name', 'scope_id', 'integration'];
+    }
+    return ['name', 'description', 'scope_id', 'summary', 'integration', 'start_date', 'end_date', 'last_updated'];
+  }
+
+  @HostListener('window:resize')
+  onResize(): void {
+    this.isMobile = window.innerWidth <= this.MOBILE_BREAKPOINT;
+  }
 
   filterForm: FormGroup;
   isFilterVisible = false;

--- a/src/app/components/projects-list/projects-list.component.ts
+++ b/src/app/components/projects-list/projects-list.component.ts
@@ -7,11 +7,13 @@ import { Project, ProjectsListParams } from '../../models/project';
 import { MatTableDataSource, MatTableModule } from '@angular/material/table';
 import { MatSortModule, Sort } from '@angular/material/sort';
 import { MatTooltipModule } from '@angular/material/tooltip';
-import { FormBuilder, FormGroup, ReactiveFormsModule } from '@angular/forms';
+import { FormBuilder, FormControl, FormGroup, ReactiveFormsModule } from '@angular/forms';
+import { debounceTime, distinctUntilChanged } from 'rxjs/operators';
 import { MatCheckboxModule } from '@angular/material/checkbox';
 import { MatButtonModule } from '@angular/material/button';
 import { MatSelectModule } from '@angular/material/select';
 import { MatFormFieldModule } from '@angular/material/form-field';
+import { MatInputModule } from '@angular/material/input';
 import { MatDialog } from '@angular/material/dialog';
 import { trigger, state, style, transition, animate } from '@angular/animations';
 import { TopBarService } from '../../services/top-bar.service';
@@ -48,6 +50,7 @@ import { formatIntegrationDuration, projectFilterGoalSummary } from '../../utils
     MatButtonModule,
     MatSelectModule,
     MatFormFieldModule,
+    MatInputModule,
     MatTooltipModule,
     RouterModule,
     DatePipe
@@ -88,6 +91,7 @@ export class ProjectsListComponent implements OnInit, OnDestroy {
     this.isMobile = window.innerWidth <= this.MOBILE_BREAKPOINT;
   }
 
+  searchControl = new FormControl('');
   filterForm: FormGroup;
   isFilterVisible = false;
   /** Default: most recently updated first (matches GET /api/projects defaults). */
@@ -138,6 +142,10 @@ export class ProjectsListComponent implements OnInit, OnDestroy {
     this.filterForm.get('activeOnly')?.valueChanges.subscribe(() => {
       this.applyClientFilterAndSort();
     });
+    this.searchControl.valueChanges.pipe(
+      debounceTime(200),
+      distinctUntilChanged()
+    ).subscribe(() => this.applyClientFilterAndSort());
     if (!this.embedded()) {
       this.loadProjects();
     }
@@ -198,7 +206,11 @@ export class ProjectsListComponent implements OnInit, OnDestroy {
 
   private applyClientFilterAndSort(): void {
     const activeOnly = this.filterForm?.get('activeOnly')?.value ?? true;
+    const nameFilter = (this.searchControl.value ?? '').trim().toLowerCase();
     let list = activeOnly ? this.allProjects.filter(p => p.active) : this.allProjects;
+    if (nameFilter) {
+      list = list.filter(p => p.name.toLowerCase().includes(nameFilter));
+    }
     if (this.usesClientSortOnly()) {
       const { active, direction } = this.sortState;
       list = [...list].sort((a, b) => {
@@ -233,6 +245,7 @@ export class ProjectsListComponent implements OnInit, OnDestroy {
     const keepScope =
       this.embedded() && this.scopeId() != null ? this.scopeId()! : null;
     this.filterForm.patchValue({ activeOnly: true, scope_id: keepScope });
+    this.searchControl.setValue('', { emitEvent: false });
     this.loadProjects();
   }
 


### PR DESCRIPTION
## Summary

### Commit 1 — Column hiding + compact layout (mobile baseline)
- On screens ≤640px `displayedColumns` switches to `[name, scope_id, integration]`, dropping Description, Start, and End columns.
- A `@HostListener('window:resize')` keeps the column set reactive to rotation/resize.
- A `@media (max-width: 640px)` block reduces padding, font size, and cell padding, and sets `overflow-x: hidden` to eliminate horizontal scrolling.

### Commit 2 — Card list layout + quick name search
- **Card layout:** on mobile the table is replaced by a vertical card list. Each card shows the project name (prominent, tappable), scope link, integration time, and a truncated description if present — all within the viewport with no horizontal scroll.
- **Quick name search:** a search `<input>` (debounced 200ms) is always visible above the filter panel on both mobile and desktop. It filters the list client-side as you type, so you never need to open the collapsible filter just to find a project by name. The "Clear" button resets it along with the other filters.

## Test plan

- [ ] Load `/projects` on desktop — all 8 columns visible, search bar visible, table unchanged
- [ ] Resize below 640px — table switches to card list; Description/Start/End disappear from any residual desktop view
- [ ] Type in the search box — list narrows immediately (debounced); clear resets it
- [ ] Tap a card on mobile — navigates to project detail
- [ ] Tap the scope link inside a card — navigates to scope detail without triggering project navigation
- [ ] Rotate device — card/table mode switches correctly
- [ ] Verify embedded mode (telescope detail page) also shows cards on mobile

https://claude.ai/code/session_019CctiZnbmqUX9iKiCVbNcn