### PR TITLE
Add sky map visualization and optical parameter tracking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Hevelius Web Interface Changelog
 
+0.6.0 (unreleased)
+
+- Detailed telescope view extended: many new parameters shown (F number,
+  default rotation, camera details, FOV etc).
+- Default camera rotation for a telescope is now supported.
+- Camera rotation for a project is now supported.
+
 0.5.0 (2026-05-27)
 
 - Tweaked the interface to be more phone friendly

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@
   default rotation, camera details, FOV etc).
 - Default camera rotation for a telescope is now supported.
 - Camera rotation for a project is now supported.
+- Sky Map page (`/sky-map`) shows active projects on an Aladin Lite all-sky view
+  with per-telescope FOV overlays and scope filters.
+- Project detail includes a Sky View (DSS) with the project FOV rectangle.
+- Optical parameters (focal length, sensor size, pixel pitch) can be set when
+  creating or editing a project; create form auto-fills from the selected telescope.
 
 0.5.0 (2026-05-27)
 

--- a/README.md
+++ b/README.md
@@ -11,20 +11,28 @@ It's in the very early stages of development. It requires [hevelius backend](htt
 to be running. There's also the [the runner component](https://github.com/tomaszmrugalski/hevelius-runner) that should be
 running on a machine that is controlling the telescope. The hevelius-web is not interacting with the runner directly.
 
-The software is implemented in Angular and Typescript.
+The web interface is implemented using Angular and Typescript.
 
 ## Status
 
-As of May 2025, the following features are available:
+As of July 2026, the following features are available:
 
-- Login
-- List of tasks
-- Adding new tasks
-- Editing tasks (long press a task)
-- List of telescopes
-- Catalogs (NGC,IC,Messier,Caldwell)
+- Login with JWT sessions (activity extends timeout); user profile with Gravatar
+- Tasks: list, add, edit; sorting, filtering, and pagination
+- Sensors: add, edit, list, sort camera sensors and their parameters.
+- Telescopes: add, edit, list, sort telescopes and their parameters.
+  detailed view (optics, sensor, FOV, location map), default camera
+  rotation; filters and sensors management
+- Projects: create/edit/delete, subframes and integration progress, publications
+  (AstroBin, Facebook, X, Flickr, and more), catalog lookup for RA/Dec on create.
+- Objects (`/objects`): search and filter by catalog, name, constellation, and
+  sky proximity; Catalogs page (`/catalogs`) lists installed catalogs
+- Sky Map (`/sky-map`): Aladin Lite all-sky view of active projects with FOV
+  overlays; project detail includes a DSS sky view with the project FOV
+- Night plan (experimental); About panel
 
-The interface is responsive and should work on any device. It was tested on desktop (Ubuntu 24, Windows), and mobile (iPhone 14 Pro).
+The interface is responsive (phone-friendly layouts for Objects, Catalogs, and
+projects). It was tested on desktop (Ubuntu, Windows) and mobile (iPhone).
 
 ## Documentation
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "@angular/material": "^21.2.14",
         "@angular/platform-browser": "^21.2.11",
         "@angular/router": "^21.2.17",
+        "aladin-lite": "^3.9.0-beta",
         "leaflet": "^1.9.4",
         "rxjs": "^7.8.0",
         "tslib": "^2.8.1",
@@ -4750,6 +4751,12 @@
           "optional": true
         }
       }
+    },
+    "node_modules/aladin-lite": {
+      "version": "3.9.0-beta",
+      "resolved": "https://registry.npmjs.org/aladin-lite/-/aladin-lite-3.9.0-beta.tgz",
+      "integrity": "sha512-Z4AGlrJnIr+wfGlx7r7tr/k9TrWnZUN9CZqPRvYMaUVJWAzuqv75rz2tRVUtnUpELww6e2t+KcKAl0jzl15NvQ==",
+      "license": "LGPL-3.0-or-later"
     },
     "node_modules/algoliasearch": {
       "version": "5.48.1",

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "@angular/material": "^21.2.14",
     "@angular/platform-browser": "^21.2.11",
     "@angular/router": "^21.2.17",
+    "aladin-lite": "^3.9.0-beta",
     "leaflet": "^1.9.4",
     "rxjs": "^7.8.0",
     "tslib": "^2.8.1",

--- a/src/app/app-routing.module.ts
+++ b/src/app/app-routing.module.ts
@@ -12,6 +12,7 @@ import { FiltersListComponent } from './components/filters-list/filters-list.com
 import { ObjectsComponent } from './components/objects/objects.component';
 import { CatalogsListComponent } from './components/catalogs-list/catalogs-list.component';
 import { UserComponent } from './components/user/user.component';
+import { SkyMapComponent } from './components/sky-map/sky-map.component';
 import { AuthGuard } from './guards/auth.guard';
 
 export const routes: Routes = [
@@ -32,6 +33,7 @@ export const routes: Routes = [
       { path: 'objects', component: ObjectsComponent },
       { path: 'catalogs', component: CatalogsListComponent },
       { path: 'user', component: UserComponent },
+      { path: 'sky-map', component: SkyMapComponent },
       { path: '', redirectTo: 'projects', pathMatch: 'full' }
     ]
   },

--- a/src/app/components/layout/layout.component.html
+++ b/src/app/components/layout/layout.component.html
@@ -38,6 +38,10 @@
       <mat-icon>filter_alt</mat-icon>
       <span>Filters</span>
     </button>
+    <button mat-menu-item routerLink="/sky-map">
+      <mat-icon>map</mat-icon>
+      <span>Sky Map</span>
+    </button>
     <button mat-menu-item routerLink="/objects">
       <mat-icon>star</mat-icon>
       <span>Objects</span>

--- a/src/app/components/project-detail/project-detail.component.html
+++ b/src/app/components/project-detail/project-detail.component.html
@@ -67,6 +67,24 @@
       </mat-card-content>
     </mat-card>
 
+    @if (hasFov) {
+      <mat-card class="sky-view-card">
+        <mat-card-header>
+          <mat-card-title>Sky View</mat-card-title>
+        </mat-card-header>
+        <mat-card-content>
+          <app-sky-view
+            [ra]="project.ra!"
+            [dec]="project.decl!"
+            [fovWidthDeg]="fovWidthDeg"
+            [fovHeightDeg]="fovHeightDeg"
+            [rotation]="project.rotation ?? 0"
+            [fovMultiplier]="4"
+          />
+        </mat-card-content>
+      </mat-card>
+    }
+
     <div class="subframes-section">
       <div class="subframes-header">
         <h2>Subframes</h2>

--- a/src/app/components/project-detail/project-detail.component.html
+++ b/src/app/components/project-detail/project-detail.component.html
@@ -33,7 +33,7 @@
           (<strong>ID:</strong>
           <a [routerLink]="['/scopes', project.scope_id]">{{ project.scope_id }}</a>)
         </p>
-        <p><strong>RA:</strong> {{ formatRA(project.ra) }} <strong>Dec:</strong> {{ formatDec(project.decl) }} <strong>Rotation:</strong> {{ project.rotation != null ? (project.rotation + '°') : '—' }}</p>
+        <p><strong>RA:</strong> {{ formatRA(project.ra) }} <strong>Dec:</strong> {{ formatDec(project.decl) }} <strong>Rotation:</strong> {{ project.rotation !== null ? (project.rotation + '°') : '—' }}</p>
         <p><strong>Start date:</strong> {{ formatCalendarDate(project.start_date) }}</p>
         <p><strong>End date:</strong> {{ formatCalendarDate(project.end_date) }}</p>
         <p class="publications-row">

--- a/src/app/components/project-detail/project-detail.component.html
+++ b/src/app/components/project-detail/project-detail.component.html
@@ -33,7 +33,7 @@
           (<strong>ID:</strong>
           <a [routerLink]="['/scopes', project.scope_id]">{{ project.scope_id }}</a>)
         </p>
-        <p><strong>RA:</strong> {{ formatRA(project.ra) }} <strong>Dec:</strong> {{ formatDec(project.decl) }} <strong>Rotation:</strong> {{ project.rotation !== null ? (project.rotation + '°') : '—' }}</p>
+        <p><strong>RA:</strong> {{ formatRA(project.ra) }} <strong>Dec:</strong> {{ formatDec(project.decl) }} <strong>Rotation:</strong> {{ formatRotation(project.rotation) }}</p>
         <p><strong>Start date:</strong> {{ formatCalendarDate(project.start_date) }}</p>
         <p><strong>End date:</strong> {{ formatCalendarDate(project.end_date) }}</p>
         <p class="publications-row">

--- a/src/app/components/project-detail/project-detail.component.html
+++ b/src/app/components/project-detail/project-detail.component.html
@@ -33,7 +33,7 @@
           (<strong>ID:</strong>
           <a [routerLink]="['/scopes', project.scope_id]">{{ project.scope_id }}</a>)
         </p>
-        <p><strong>RA:</strong> {{ formatRA(project.ra) }} <strong>Dec:</strong> {{ formatDec(project.decl) }}</p>
+        <p><strong>RA:</strong> {{ formatRA(project.ra) }} <strong>Dec:</strong> {{ formatDec(project.decl) }} <strong>Rotation:</strong> {{ project.rotation != null ? (project.rotation + '°') : '—' }}</p>
         <p><strong>Start date:</strong> {{ formatCalendarDate(project.start_date) }}</p>
         <p><strong>End date:</strong> {{ formatCalendarDate(project.end_date) }}</p>
         <p class="publications-row">

--- a/src/app/components/project-detail/project-detail.component.ts
+++ b/src/app/components/project-detail/project-detail.component.ts
@@ -28,6 +28,7 @@ import {
   subframeGoalSeconds,
   subframeProgressPercent
 } from '../../utils/project-integration';
+import { SkyViewComponent, computeFovDeg } from '../sky-view/sky-view.component';
 
 @Component({
   selector: 'app-project-detail',
@@ -44,7 +45,8 @@ import {
     MatProgressBarModule,
     DatePipe,
     TasksComponent,
-    ProjectPublicationsComponent
+    ProjectPublicationsComponent,
+    SkyViewComponent
   ]
 })
 export class ProjectDetailComponent implements OnInit {
@@ -293,6 +295,21 @@ export class ProjectDetailComponent implements OnInit {
 
   projectSummaryLine(): string {
     return this.project ? projectFilterGoalSummary(this.project) : '';
+  }
+
+  get hasFov(): boolean {
+    const p = this.project;
+    return !!(p?.focal && p?.resx && p?.resy && p?.pixel_x && p?.pixel_y && p?.ra != null && p?.decl != null);
+  }
+
+  get fovWidthDeg(): number {
+    const p = this.project!;
+    return computeFovDeg(p.resx!, p.pixel_x!, p.focal!);
+  }
+
+  get fovHeightDeg(): number {
+    const p = this.project!;
+    return computeFovDeg(p.resy!, p.pixel_y!, p.focal!);
   }
 
   deleteSubframe(sub: ProjectSubframe): void {

--- a/src/app/components/project-detail/project-detail.component.ts
+++ b/src/app/components/project-detail/project-detail.component.ts
@@ -167,6 +167,7 @@ export class ProjectDetailComponent implements OnInit {
         initialDescription: this.project.description ?? null,
         initialRa: this.project.ra,
         initialDecl: this.project.decl,
+        initialRotation: this.project.rotation ?? null,
         initialRegexps: this.project.regexps,
         initialActive: this.project.active,
         initialStartDate: this.project.start_date ?? null,

--- a/src/app/components/project-detail/project-detail.component.ts
+++ b/src/app/components/project-detail/project-detail.component.ts
@@ -28,7 +28,8 @@ import {
   subframeGoalSeconds,
   subframeProgressPercent
 } from '../../utils/project-integration';
-import { SkyViewComponent, computeFovDeg } from '../sky-view/sky-view.component';
+import { SkyViewComponent } from '../sky-view/sky-view.component';
+import { computeFovDeg } from '../../utils/fov';
 
 @Component({
   selector: 'app-project-detail',
@@ -153,6 +154,11 @@ export class ProjectDetailComponent implements OnInit {
     return this.coordsFormatter.formatDec(dec);
   }
 
+  formatRotation(value: number | null | undefined): string {
+    if (value == null) return '—';
+    return `${value}°`;
+  }
+
   getScopeName(): string {
     return this.telescope?.name ?? '—';
   }
@@ -160,7 +166,7 @@ export class ProjectDetailComponent implements OnInit {
   editProject(): void {
     if (!this.project) return;
     const ref = this.dialog.open(ProjectEditDialogComponent, {
-      width: '480px',
+      width: '520px',
       data: {
         projectId: this.project.project_id,
         initialScopeId: this.project.scope_id,
@@ -172,7 +178,12 @@ export class ProjectDetailComponent implements OnInit {
         initialActive: this.project.active,
         initialStartDate: this.project.start_date ?? null,
         initialEndDate: this.project.end_date ?? null,
-        initialPublications: this.project.publications ?? null
+        initialPublications: this.project.publications ?? null,
+        initialFocal: this.project.focal ?? null,
+        initialResx: this.project.resx ?? null,
+        initialResy: this.project.resy ?? null,
+        initialPixelX: this.project.pixel_x ?? null,
+        initialPixelY: this.project.pixel_y ?? null
       }
     });
     ref.afterClosed().subscribe((result: boolean | 'deleted' | undefined) => {

--- a/src/app/components/project-edit-dialog/project-edit-dialog.component.css
+++ b/src/app/components/project-edit-dialog/project-edit-dialog.component.css
@@ -1,11 +1,3 @@
-.dialog-form {
-  display: flex;
-  flex-direction: column;
-  min-width: 320px;
-  max-height: 70vh;
-  overflow-y: auto;
-}
-
 .full-width {
   width: 100%;
 }
@@ -14,14 +6,53 @@
   flex: 1;
 }
 
-.field-gap {
-  height: 8px;
+/* Scroll only on mat-dialog-content; avoid nested overflow (double scrollbars) */
+mat-dialog-content form {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  min-width: min(100%, 480px);
+  /* Room for outline notch / floating label on first field (avoids top clipping) */
+  padding-top: 0.5rem;
+  padding-bottom: 0.5rem;
+}
+
+/* Extra air after multi-line fields so hints/subscripts clear the next outline */
+mat-dialog-content form mat-form-field:has(textarea) {
+  margin-bottom: 0.35rem;
+}
+
+mat-dialog-content form mat-checkbox {
+  margin-top: 0.25rem;
+}
+
+/* Hint row: short wrapping text + single-line sexagesimal preview */
+mat-hint.coord-hint {
+  display: flex;
+  flex-direction: row;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 12px;
+  width: 100%;
+  box-sizing: border-box;
+}
+
+mat-hint.coord-hint .coord-hint-main {
+  flex: 1 1 auto;
+  min-width: 0;
+  line-height: 1.35;
+}
+
+mat-hint.coord-hint .coord-hint-preview {
+  flex: 0 0 auto;
+  white-space: nowrap;
+  text-align: right;
 }
 
 .fov-section {
-  border-top: 1px solid rgba(0,0,0,0.12);
+  border-top: 1px solid rgba(0, 0, 0, 0.12);
   padding-top: 8px;
-  margin-top: 8px;
+  margin-top: 4px;
 }
 
 .fov-section-title {
@@ -48,9 +79,12 @@
   gap: 8px;
 }
 
-.fov-hint {
-  font-size: 11px;
-  color: rgba(0,0,0,0.54);
-  margin-top: 4px;
+.fov-focal {
+  grid-column: 1 / -1;
 }
 
+.fov-hint {
+  font-size: 11px;
+  color: rgba(0, 0, 0, 0.54);
+  margin-top: 4px;
+}

--- a/src/app/components/project-edit-dialog/project-edit-dialog.component.css
+++ b/src/app/components/project-edit-dialog/project-edit-dialog.component.css
@@ -18,3 +18,39 @@
   height: 8px;
 }
 
+.fov-section {
+  border-top: 1px solid rgba(0,0,0,0.12);
+  padding-top: 8px;
+  margin-top: 8px;
+}
+
+.fov-section-title {
+  font-size: 13px;
+  font-weight: 500;
+  margin-bottom: 8px;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.fov-chip {
+  background: #e3f2fd;
+  color: #1565c0;
+  border-radius: 12px;
+  padding: 2px 10px;
+  font-size: 12px;
+  font-weight: 600;
+}
+
+.fov-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 8px;
+}
+
+.fov-hint {
+  font-size: 11px;
+  color: rgba(0,0,0,0.54);
+  margin-top: 4px;
+}
+

--- a/src/app/components/project-edit-dialog/project-edit-dialog.component.html
+++ b/src/app/components/project-edit-dialog/project-edit-dialog.component.html
@@ -55,6 +55,9 @@
       <mat-label>Rotation (°)</mat-label>
       <input matInput formControlName="rotation" type="number" min="0" max="360" step="0.1" placeholder="e.g. 90.5">
       <mat-hint>Camera position angle, degrees East of North (0–360). Leave empty to clear.</mat-hint>
+      @if (form.get('rotation')?.touched && form.get('rotation')?.hasError('rotationRange')) {
+        <mat-error>Rotation must be between 0 and 360</mat-error>
+      }
     </mat-form-field>
 
     <mat-form-field appearance="outline" class="full-width" subscriptSizing="dynamic">
@@ -76,6 +79,35 @@
     </mat-form-field>
 
     <mat-checkbox formControlName="active">Project active</mat-checkbox>
+
+    <div class="fov-section">
+      <p class="fov-section-title">Optical parameters
+        @if (fovChip) { <span class="fov-chip">FOV {{ fovChip }}</span> }
+      </p>
+      <div class="fov-grid">
+        <mat-form-field appearance="outline" subscriptSizing="dynamic">
+          <mat-label>Focal length (mm)</mat-label>
+          <input matInput type="number" formControlName="focal">
+        </mat-form-field>
+        <mat-form-field appearance="outline" subscriptSizing="dynamic">
+          <mat-label>Sensor width (px)</mat-label>
+          <input matInput type="number" formControlName="resx">
+        </mat-form-field>
+        <mat-form-field appearance="outline" subscriptSizing="dynamic">
+          <mat-label>Sensor height (px)</mat-label>
+          <input matInput type="number" formControlName="resy">
+        </mat-form-field>
+        <mat-form-field appearance="outline" subscriptSizing="dynamic">
+          <mat-label>Pixel pitch X (µm)</mat-label>
+          <input matInput type="number" formControlName="pixel_x">
+        </mat-form-field>
+        <mat-form-field appearance="outline" subscriptSizing="dynamic">
+          <mat-label>Pixel pitch Y (µm)</mat-label>
+          <input matInput type="number" formControlName="pixel_y">
+        </mat-form-field>
+      </div>
+      <p class="fov-hint">Snapshot used for FOV display. Clear a field to unset it.</p>
+    </div>
   </form>
 </mat-dialog-content>
 

--- a/src/app/components/project-edit-dialog/project-edit-dialog.component.html
+++ b/src/app/components/project-edit-dialog/project-edit-dialog.component.html
@@ -1,7 +1,7 @@
 <h2 mat-dialog-title>Edit project</h2>
 <mat-dialog-content>
   <form [formGroup]="form" class="dialog-form">
-    <mat-form-field appearance="outline" class="full-width">
+    <mat-form-field appearance="outline" class="full-width" subscriptSizing="dynamic">
       <mat-label>Telescope</mat-label>
       <mat-select formControlName="scope_id" required>
         @for (t of activeTelescopes; track t.scope_id) {
@@ -15,8 +15,6 @@
       <textarea matInput formControlName="description" rows="2"></textarea>
     </mat-form-field>
 
-    <div class="field-gap"></div>
-
     <mat-form-field appearance="outline" class="full-width" subscriptSizing="dynamic">
       <mat-label>Regexps</mat-label>
       <input matInput formControlName="regexps">
@@ -25,11 +23,13 @@
 
     <mat-form-field appearance="outline" class="full-width" subscriptSizing="dynamic">
       <mat-label>RA (hours)</mat-label>
-      <input matInput formControlName="ra" placeholder="Decimal or H:M:S" autocomplete="off">
-      <mat-hint>Decimal hours (0–24) or sexagesimal</mat-hint>
-      @if (raSexagesimalHint) {
-        <mat-hint align="end">{{ raSexagesimalHint }}</mat-hint>
-      }
+      <input matInput formControlName="ra" placeholder="e.g. 0.712 or 00:42:43.2" autocomplete="off">
+      <mat-hint class="coord-hint">
+        <span class="coord-hint-main">Decimal hours (0–24) or sexagesimal</span>
+        @if (raSexagesimalHint) {
+          <span class="coord-hint-preview">{{ raSexagesimalHint }}</span>
+        }
+      </mat-hint>
       @if (form.get('ra')?.touched && form.get('ra')?.hasError('required')) {
         <mat-error>RA is required</mat-error>
       } @else if (form.get('ra')?.touched && form.get('ra')?.hasError('raParse')) {
@@ -39,11 +39,13 @@
 
     <mat-form-field appearance="outline" class="full-width" subscriptSizing="dynamic">
       <mat-label>Dec (degrees)</mat-label>
-      <input matInput formControlName="decl" placeholder="Decimal or ±D:M:S" autocomplete="off">
-      <mat-hint>Decimal degrees or sexagesimal</mat-hint>
-      @if (decSexagesimalHint) {
-        <mat-hint align="end">{{ decSexagesimalHint }}</mat-hint>
-      }
+      <input matInput formControlName="decl" placeholder="e.g. 41.27 or +41:16:12" autocomplete="off">
+      <mat-hint class="coord-hint">
+        <span class="coord-hint-main">Decimal degrees or sexagesimal</span>
+        @if (decSexagesimalHint) {
+          <span class="coord-hint-preview">{{ decSexagesimalHint }}</span>
+        }
+      </mat-hint>
       @if (form.get('decl')?.touched && form.get('decl')?.hasError('required')) {
         <mat-error>Dec is required</mat-error>
       } @else if (form.get('decl')?.touched && form.get('decl')?.hasError('decParse')) {
@@ -86,10 +88,6 @@
       </p>
       <div class="fov-grid">
         <mat-form-field appearance="outline" subscriptSizing="dynamic">
-          <mat-label>Focal length (mm)</mat-label>
-          <input matInput type="number" formControlName="focal">
-        </mat-form-field>
-        <mat-form-field appearance="outline" subscriptSizing="dynamic">
           <mat-label>Sensor width (px)</mat-label>
           <input matInput type="number" formControlName="resx">
         </mat-form-field>
@@ -105,6 +103,10 @@
           <mat-label>Pixel pitch Y (µm)</mat-label>
           <input matInput type="number" formControlName="pixel_y">
         </mat-form-field>
+        <mat-form-field appearance="outline" class="fov-focal" subscriptSizing="dynamic">
+          <mat-label>Focal length (mm)</mat-label>
+          <input matInput type="number" formControlName="focal">
+        </mat-form-field>
       </div>
       <p class="fov-hint">Snapshot used for FOV display. Clear a field to unset it.</p>
     </div>
@@ -119,4 +121,3 @@
     {{ saving ? 'Saving…' : 'Save' }}
   </button>
 </mat-dialog-actions>
-

--- a/src/app/components/project-edit-dialog/project-edit-dialog.component.html
+++ b/src/app/components/project-edit-dialog/project-edit-dialog.component.html
@@ -52,6 +52,12 @@
     </mat-form-field>
 
     <mat-form-field appearance="outline" class="full-width" subscriptSizing="dynamic">
+      <mat-label>Rotation (°)</mat-label>
+      <input matInput formControlName="rotation" type="number" min="0" max="360" step="0.1" placeholder="e.g. 90.5">
+      <mat-hint>Camera position angle, degrees East of North (0–360). Leave empty to clear.</mat-hint>
+    </mat-form-field>
+
+    <mat-form-field appearance="outline" class="full-width" subscriptSizing="dynamic">
       <mat-label>Publications</mat-label>
       <textarea matInput formControlName="publications" rows="2"></textarea>
       <mat-hint>Space-separated URLs. Leave empty to clear</mat-hint>

--- a/src/app/components/project-edit-dialog/project-edit-dialog.component.ts
+++ b/src/app/components/project-edit-dialog/project-edit-dialog.component.ts
@@ -43,6 +43,7 @@ export interface ProjectEditDialogData {
   initialDescription?: string | null;
   initialRa?: number;
   initialDecl?: number;
+  initialRotation?: number | null;
   initialRegexps?: string;
   initialActive?: boolean;
   initialStartDate?: string | null;
@@ -112,12 +113,17 @@ export class ProjectEditDialogComponent {
       this.dialogData.initialEndDate != null && String(this.dialogData.initialEndDate).trim() !== ''
         ? String(this.dialogData.initialEndDate).trim().slice(0, 10)
         : '';
+    const rotStr =
+      this.dialogData.initialRotation != null && Number.isFinite(this.dialogData.initialRotation)
+        ? String(this.dialogData.initialRotation)
+        : '';
     this.form = this.fb.group({
       scope_id: [this.dialogData.initialScopeId, Validators.required],
       description: [this.dialogData.initialDescription ?? ''],
       regexps: [this.dialogData.initialRegexps ?? ''],
       ra: [raStr, [Validators.required, raFieldValidator]],
       decl: [decStr, [Validators.required, decFieldValidator]],
+      rotation: [rotStr],
       active: [this.dialogData.initialActive ?? true],
       start_date: [startStr],
       end_date: [endStr],
@@ -188,12 +194,15 @@ export class ProjectEditDialogComponent {
     const sd = String(v.start_date ?? '').trim().slice(0, 10);
     const ed = String(v.end_date ?? '').trim().slice(0, 10);
     const pubs = String(v.publications ?? '').trim();
+    const rotRaw = String(v.rotation ?? '').trim();
+    const rotation = rotRaw === '' ? null : Number(rotRaw);
     const body: ProjectUpdate = {
       scope_id: Number(v.scope_id),
       description: String(v.description ?? '').trim(),
       regexps: String(v.regexps ?? '').trim(),
       ra,
       decl,
+      rotation: Number.isFinite(rotation) ? rotation : null,
       active: Boolean(v.active),
       start_date: sd === '' ? null : sd,
       end_date: ed === '' ? null : ed,

--- a/src/app/components/project-edit-dialog/project-edit-dialog.component.ts
+++ b/src/app/components/project-edit-dialog/project-edit-dialog.component.ts
@@ -19,6 +19,7 @@ import { ProjectsService } from '../../services/projects.service';
 import { ProjectUpdate } from '../../models/project';
 import { CoordsFormatterService } from '../../services/coords-formatter.service';
 import { parseDecDegrees, parseRAHours } from '../../utils/coord-parse';
+import { computeFovDeg } from '../../utils/fov';
 
 @Component({
   selector: 'app-delete-project-confirm-dialog',
@@ -49,6 +50,11 @@ export interface ProjectEditDialogData {
   initialStartDate?: string | null;
   initialEndDate?: string | null;
   initialPublications?: string | null;
+  initialFocal?: number | null;
+  initialResx?: number | null;
+  initialResy?: number | null;
+  initialPixelX?: number | null;
+  initialPixelY?: number | null;
 }
 
 function raFieldValidator(c: AbstractControl): ValidationErrors | null {
@@ -65,6 +71,23 @@ function decFieldValidator(c: AbstractControl): ValidationErrors | null {
     return null;
   }
   return parseDecDegrees(raw) === null ? { decParse: true } : null;
+}
+
+/** Optional camera rotation in degrees East of North (0–360). Empty clears. */
+function optionalRotation(c: AbstractControl): ValidationErrors | null {
+  const raw = String(c.value ?? '').trim();
+  if (!raw) {
+    return null;
+  }
+  const n = Number(raw);
+  if (!Number.isFinite(n) || n < 0 || n > 360) {
+    return { rotationRange: true };
+  }
+  return null;
+}
+
+function numStr(v: number | null | undefined): string {
+  return v != null && Number.isFinite(v) ? String(v) : '';
 }
 
 @Component({
@@ -123,11 +146,16 @@ export class ProjectEditDialogComponent {
       regexps: [this.dialogData.initialRegexps ?? ''],
       ra: [raStr, [Validators.required, raFieldValidator]],
       decl: [decStr, [Validators.required, decFieldValidator]],
-      rotation: [rotStr],
+      rotation: [rotStr, optionalRotation],
       active: [this.dialogData.initialActive ?? true],
       start_date: [startStr],
       end_date: [endStr],
-      publications: [this.dialogData.initialPublications ?? '']
+      publications: [this.dialogData.initialPublications ?? ''],
+      focal: [numStr(this.dialogData.initialFocal)],
+      resx: [numStr(this.dialogData.initialResx)],
+      resy: [numStr(this.dialogData.initialResy)],
+      pixel_x: [numStr(this.dialogData.initialPixelX)],
+      pixel_y: [numStr(this.dialogData.initialPixelY)]
     });
 
     this.telescopeService.getTelescopes().subscribe({
@@ -138,6 +166,21 @@ export class ProjectEditDialogComponent {
         this.activeTelescopes = [];
       }
     });
+  }
+
+  get fovChip(): string | null {
+    const v = this.form.getRawValue();
+    const focal = Number(String(v.focal ?? '').trim());
+    const resx = Number(String(v.resx ?? '').trim());
+    const resy = Number(String(v.resy ?? '').trim());
+    const pixel_x = Number(String(v.pixel_x ?? '').trim());
+    const pixel_y = Number(String(v.pixel_y ?? '').trim());
+    if (![focal, resx, resy, pixel_x, pixel_y].every(n => Number.isFinite(n) && n > 0)) {
+      return null;
+    }
+    const w = computeFovDeg(resx, pixel_x, focal);
+    const h = computeFovDeg(resy, pixel_y, focal);
+    return `${w.toFixed(2)}° × ${h.toFixed(2)}°`;
   }
 
   get raSexagesimalHint(): string {
@@ -196,17 +239,28 @@ export class ProjectEditDialogComponent {
     const pubs = String(v.publications ?? '').trim();
     const rotRaw = String(v.rotation ?? '').trim();
     const rotation = rotRaw === '' ? null : Number(rotRaw);
+    const optNum = (x: unknown): number | null => {
+      const raw = String(x ?? '').trim();
+      if (!raw) return null;
+      const n = Number(raw);
+      return Number.isFinite(n) ? n : null;
+    };
     const body: ProjectUpdate = {
       scope_id: Number(v.scope_id),
       description: String(v.description ?? '').trim(),
       regexps: String(v.regexps ?? '').trim(),
       ra,
       decl,
-      rotation: Number.isFinite(rotation) ? rotation : null,
+      rotation: rotation != null && Number.isFinite(rotation) ? rotation : null,
       active: Boolean(v.active),
       start_date: sd === '' ? null : sd,
       end_date: ed === '' ? null : ed,
-      publications: pubs === '' ? null : pubs
+      publications: pubs === '' ? null : pubs,
+      focal: optNum(v.focal),
+      resx: optNum(v.resx),
+      resy: optNum(v.resy),
+      pixel_x: optNum(v.pixel_x),
+      pixel_y: optNum(v.pixel_y)
     };
 
     this.projectsService.updateProject(this.dialogData.projectId, body).subscribe({

--- a/src/app/components/project-edit-dialog/project-edit-dialog.component.ts
+++ b/src/app/components/project-edit-dialog/project-edit-dialog.component.ts
@@ -90,6 +90,11 @@ function numStr(v: number | null | undefined): string {
   return v != null && Number.isFinite(v) ? String(v) : '';
 }
 
+/** Format a coordinate for the form input, capped at 6 decimal digits. */
+function formatCoordInput(v: number): string {
+  return Number(v.toFixed(6)).toString();
+}
+
 @Component({
   selector: 'app-project-edit-dialog',
   templateUrl: './project-edit-dialog.component.html',
@@ -122,11 +127,11 @@ export class ProjectEditDialogComponent {
   constructor() {
     const raStr =
       this.dialogData.initialRa != null && Number.isFinite(this.dialogData.initialRa)
-        ? String(this.dialogData.initialRa)
+        ? formatCoordInput(this.dialogData.initialRa)
         : '';
     const decStr =
       this.dialogData.initialDecl != null && Number.isFinite(this.dialogData.initialDecl)
-        ? String(this.dialogData.initialDecl)
+        ? formatCoordInput(this.dialogData.initialDecl)
         : '';
     const startStr =
       this.dialogData.initialStartDate != null && String(this.dialogData.initialStartDate).trim() !== ''

--- a/src/app/components/project-form-dialog/project-form-dialog.component.css
+++ b/src/app/components/project-form-dialog/project-form-dialog.component.css
@@ -22,3 +22,39 @@ mat-dialog-content form {
 .similar-warning-icon {
   margin-right: 4px;
 }
+
+.fov-section {
+  border-top: 1px solid rgba(0,0,0,0.12);
+  padding-top: 8px;
+  margin-top: 4px;
+}
+
+.fov-section-title {
+  font-size: 13px;
+  font-weight: 500;
+  margin-bottom: 8px;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.fov-chip {
+  background: #e3f2fd;
+  color: #1565c0;
+  border-radius: 12px;
+  padding: 2px 10px;
+  font-size: 12px;
+  font-weight: 600;
+}
+
+.fov-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 8px;
+}
+
+.fov-hint {
+  font-size: 11px;
+  color: rgba(0,0,0,0.54);
+  margin-top: 4px;
+}

--- a/src/app/components/project-form-dialog/project-form-dialog.component.html
+++ b/src/app/components/project-form-dialog/project-form-dialog.component.html
@@ -69,6 +69,14 @@
       }
     </mat-form-field>
     <mat-form-field appearance="outline" class="full-width" subscriptSizing="dynamic">
+      <mat-label>Rotation (°)</mat-label>
+      <input matInput formControlName="rotation" type="number" min="0" max="360" step="0.1" placeholder="e.g. 90.5">
+      <mat-hint>Camera position angle, degrees East of North (0–360). Leave empty to use telescope default.</mat-hint>
+      @if (form.get('rotation')?.touched && form.get('rotation')?.hasError('rotationRange')) {
+        <mat-error>Rotation must be between 0 and 360</mat-error>
+      }
+    </mat-form-field>
+    <mat-form-field appearance="outline" class="full-width" subscriptSizing="dynamic">
       <mat-label>Publications</mat-label>
       <textarea matInput formControlName="publications" rows="2"></textarea>
       <mat-hint>Space-separated URLs (Facebook, Flickr, AstroBin, etc.). Optional</mat-hint>

--- a/src/app/components/project-form-dialog/project-form-dialog.component.html
+++ b/src/app/components/project-form-dialog/project-form-dialog.component.html
@@ -84,6 +84,36 @@
       <mat-hint>Optional</mat-hint>
     </mat-form-field>
     <mat-checkbox formControlName="active">Active</mat-checkbox>
+
+    <div class="fov-section">
+      <p class="fov-section-title">Optical parameters
+        @if (fovLoadPending) { <em>(loading…)</em> }
+        @if (fovChip) { <span class="fov-chip">FOV {{ fovChip }}</span> }
+      </p>
+      <div class="fov-grid">
+        <mat-form-field appearance="outline" subscriptSizing="dynamic">
+          <mat-label>Focal length (mm)</mat-label>
+          <input matInput type="number" formControlName="focal">
+        </mat-form-field>
+        <mat-form-field appearance="outline" subscriptSizing="dynamic">
+          <mat-label>Sensor width (px)</mat-label>
+          <input matInput type="number" formControlName="resx">
+        </mat-form-field>
+        <mat-form-field appearance="outline" subscriptSizing="dynamic">
+          <mat-label>Sensor height (px)</mat-label>
+          <input matInput type="number" formControlName="resy">
+        </mat-form-field>
+        <mat-form-field appearance="outline" subscriptSizing="dynamic">
+          <mat-label>Pixel pitch X (µm)</mat-label>
+          <input matInput type="number" formControlName="pixel_x">
+        </mat-form-field>
+        <mat-form-field appearance="outline" subscriptSizing="dynamic">
+          <mat-label>Pixel pitch Y (µm)</mat-label>
+          <input matInput type="number" formControlName="pixel_y">
+        </mat-form-field>
+      </div>
+      <p class="fov-hint">Auto-filled from the selected telescope's sensor. You can override before saving.</p>
+    </div>
   </form>
 </mat-dialog-content>
 <mat-dialog-actions align="end">

--- a/src/app/components/project-form-dialog/project-form-dialog.component.spec.ts
+++ b/src/app/components/project-form-dialog/project-form-dialog.component.spec.ts
@@ -5,6 +5,7 @@ import { of } from 'rxjs';
 import { CatalogsService } from '../../services/catalogs.service';
 import { CoordsFormatterService } from '../../services/coords-formatter.service';
 import { ProjectsService } from '../../services/projects.service';
+import { TelescopeService } from '../../services/telescope.service';
 import { ProjectFormDialogComponent, findSimilarProjects, sequenceRatio } from './project-form-dialog.component';
 
 describe('sequenceRatio', () => {
@@ -75,6 +76,7 @@ describe('ProjectFormDialogComponent', () => {
       providers: [
         { provide: ProjectsService, useValue: projectsService },
         { provide: CatalogsService, useValue: { searchObjects: vi.fn().mockReturnValue(of([])) } },
+        { provide: TelescopeService, useValue: { getTelescope: vi.fn().mockReturnValue(of({ focal: null, sensor: null })) } },
         CoordsFormatterService,
         { provide: MatDialogRef, useValue: { close: vi.fn() } },
         { provide: MatSnackBar, useValue: { open: vi.fn() } },
@@ -116,7 +118,12 @@ describe('ProjectFormDialogComponent', () => {
       regexps: '',
       active: true,
       ra: 0.7,
-      decl: 41.2
+      decl: 41.2,
+      focal: null,
+      resx: null,
+      resy: null,
+      pixel_x: null,
+      pixel_y: null
     });
   });
 
@@ -192,5 +199,40 @@ describe('ProjectFormDialogComponent', () => {
     expect(component.similarProjects.length).toBeGreaterThan(0);
     component.save();
     expect(projectsService.createProject).toHaveBeenCalled();
+  });
+
+  it('fovChip returns null when optical params are missing', () => {
+    expect(component.fovChip).toBeNull();
+  });
+
+  it('fovChip returns formatted FOV string when all optical params are set', () => {
+    component.form.patchValue({ focal: 2541, resx: 3326, resy: 2504, pixel_x: 5.4, pixel_y: 5.4 });
+    expect(component.fovChip).toMatch(/^\d+\.\d+° × \d+\.\d+°$/);
+  });
+
+  it('includes explicit optical params in the save payload', () => {
+    component.form.patchValue({
+      name: 'M31',
+      scope_id: 2,
+      ra: '0.7',
+      decl: '41.2',
+      active: true,
+      regexps: '',
+      focal: 2541,
+      resx: 3326,
+      resy: 2504,
+      pixel_x: 5.4,
+      pixel_y: 5.4
+    });
+    component.save();
+    expect(projectsService.createProject).toHaveBeenCalledWith(
+      expect.objectContaining({
+        focal: 2541,
+        resx: 3326,
+        resy: 2504,
+        pixel_x: 5.4,
+        pixel_y: 5.4
+      })
+    );
   });
 });

--- a/src/app/components/project-form-dialog/project-form-dialog.component.spec.ts
+++ b/src/app/components/project-form-dialog/project-form-dialog.component.spec.ts
@@ -76,7 +76,7 @@ describe('ProjectFormDialogComponent', () => {
       providers: [
         { provide: ProjectsService, useValue: projectsService },
         { provide: CatalogsService, useValue: { searchObjects: vi.fn().mockReturnValue(of([])) } },
-        { provide: TelescopeService, useValue: { getTelescope: vi.fn().mockReturnValue(of({ focal: null, sensor: null })) } },
+        { provide: TelescopeService, useValue: { getTelescope: vi.fn().mockReturnValue(of({ focal: null, sensor: null, default_rotation: null })) } },
         CoordsFormatterService,
         { provide: MatDialogRef, useValue: { close: vi.fn() } },
         { provide: MatSnackBar, useValue: { open: vi.fn() } },

--- a/src/app/components/project-form-dialog/project-form-dialog.component.ts
+++ b/src/app/components/project-form-dialog/project-form-dialog.component.ts
@@ -1,4 +1,4 @@
-import { Component, inject } from '@angular/core';
+import { Component, inject, OnDestroy } from '@angular/core';
 import { AbstractControl, FormBuilder, FormGroup, ReactiveFormsModule, ValidationErrors, Validators } from '@angular/forms';
 import { MatDialogRef, MAT_DIALOG_DATA, MatDialogModule } from '@angular/material/dialog';
 import { MatFormFieldModule } from '@angular/material/form-field';
@@ -11,12 +11,11 @@ import { ProjectCreate } from '../../models/project';
 import { MatSnackBar } from '@angular/material/snack-bar';
 import { CatalogsService, CatalogObject } from '../../services/catalogs.service';
 import { CoordsFormatterService } from '../../services/coords-formatter.service';
-import { TelescopeService } from '../../services/telescope.service';
-import { debounceTime, distinctUntilChanged } from 'rxjs/operators';
-import { finalize } from 'rxjs/operators';
+import { TelescopeService, Telescope } from '../../services/telescope.service';
+import { debounceTime, distinctUntilChanged, finalize, switchMap, takeUntil, catchError } from 'rxjs/operators';
+import { of, Subject } from 'rxjs';
 import { parseDecDegrees, parseRAHours } from '../../utils/coord-parse';
-import { computeFovDeg } from '../sky-view/sky-view.component';
-import { CommonModule } from '@angular/common';
+import { computeFovDeg } from '../../utils/fov';
 
 /** Longest-common-subsequence ratio, matching Python difflib.SequenceMatcher.ratio() semantics. */
 export function sequenceRatio(a: string, b: string): number {
@@ -65,6 +64,19 @@ function decFieldValidator(c: AbstractControl): ValidationErrors | null {
   return parseDecDegrees(raw) === null ? { decParse: true } : null;
 }
 
+/** Optional camera rotation in degrees East of North (0–360). Empty clears / omits. */
+function optionalRotation(c: AbstractControl): ValidationErrors | null {
+  const raw = String(c.value ?? '').trim();
+  if (!raw) {
+    return null;
+  }
+  const n = Number(raw);
+  if (!Number.isFinite(n) || n < 0 || n > 360) {
+    return { rotationRange: true };
+  }
+  return null;
+}
+
 export interface ProjectFormDialogData {
   scopes: { scope_id: number; name: string }[];
   existingProjects?: SimilarProject[];
@@ -76,7 +88,6 @@ export interface ProjectFormDialogData {
   styleUrls: ['./project-form-dialog.component.css'],
   standalone: true,
   imports: [
-    CommonModule,
     ReactiveFormsModule,
     MatDialogModule,
     MatFormFieldModule,
@@ -86,7 +97,7 @@ export interface ProjectFormDialogData {
     MatCheckboxModule
   ]
 })
-export class ProjectFormDialogComponent {
+export class ProjectFormDialogComponent implements OnDestroy {
   private fb = inject(FormBuilder);
   private projectsService = inject(ProjectsService);
   private catalogsService = inject(CatalogsService);
@@ -95,6 +106,7 @@ export class ProjectFormDialogComponent {
   private dialogRef = inject(MatDialogRef<ProjectFormDialogComponent>);
   private snackBar = inject(MatSnackBar);
   data = inject<ProjectFormDialogData>(MAT_DIALOG_DATA);
+  private destroy$ = new Subject<void>();
 
   form: FormGroup;
   catalogLookupPending = false;
@@ -109,6 +121,7 @@ export class ProjectFormDialogComponent {
       regexps: [''],
       ra: ['', [Validators.required, raFieldValidator]],
       decl: ['', [Validators.required, decFieldValidator]],
+      rotation: ['', optionalRotation],
       active: [true],
       start_date: [''],
       end_date: [''],
@@ -122,7 +135,8 @@ export class ProjectFormDialogComponent {
 
     this.form.get('name')!.valueChanges.pipe(
       debounceTime(300),
-      distinctUntilChanged()
+      distinctUntilChanged(),
+      takeUntil(this.destroy$)
     ).subscribe(name => {
       this.similarProjects = findSimilarProjects(
         String(name ?? ''),
@@ -130,24 +144,37 @@ export class ProjectFormDialogComponent {
       );
     });
 
-    this.form.get('scope_id')!.valueChanges.subscribe((scopeId: number | null) => {
-      if (!scopeId) return;
-      this.fovLoadPending = true;
-      this.telescopeService.getTelescope(scopeId).pipe(
-        finalize(() => { this.fovLoadPending = false; })
-      ).subscribe({
-        next: t => {
-          this.form.patchValue({
-            focal: t.focal ?? null,
-            resx: t.sensor?.resx ?? null,
-            resy: t.sensor?.resy ?? null,
-            pixel_x: t.sensor?.pixel_x ?? null,
-            pixel_y: t.sensor?.pixel_y ?? null
-          }, { emitEvent: false });
-        },
-        error: () => { /* leave fields as-is */ }
-      });
+    this.form.get('scope_id')!.valueChanges.pipe(
+      switchMap((scopeId: number | null) => {
+        if (!scopeId) {
+          return of(null as Telescope | null);
+        }
+        this.fovLoadPending = true;
+        return this.telescopeService.getTelescope(scopeId).pipe(
+          catchError(() => of(null as Telescope | null)),
+          finalize(() => { this.fovLoadPending = false; })
+        );
+      }),
+      takeUntil(this.destroy$)
+    ).subscribe(t => {
+      if (!t) return;
+      this.form.patchValue({
+        focal: t.focal ?? null,
+        resx: t.sensor?.resx ?? null,
+        resy: t.sensor?.resy ?? null,
+        pixel_x: t.sensor?.pixel_x ?? null,
+        pixel_y: t.sensor?.pixel_y ?? null,
+        // Prefill rotation from telescope default when the field is still empty.
+        ...(String(this.form.get('rotation')?.value ?? '').trim() === '' && t.default_rotation != null
+          ? { rotation: String(t.default_rotation) }
+          : {})
+      }, { emitEvent: false });
     });
+  }
+
+  ngOnDestroy(): void {
+    this.destroy$.next();
+    this.destroy$.complete();
   }
 
   get fovChip(): string | null {
@@ -265,6 +292,13 @@ export class ProjectFormDialogComponent {
     const sd = String(value.start_date ?? '').trim().slice(0, 10);
     const ed = String(value.end_date ?? '').trim().slice(0, 10);
     const pubs = String(value.publications ?? '').trim();
+    const rotRaw = String(value.rotation ?? '').trim();
+    const rotation = rotRaw === '' ? null : Number(rotRaw);
+    const optNum = (x: unknown): number | null => {
+      if (x == null || x === '') return null;
+      const n = Number(x);
+      return Number.isFinite(n) ? n : null;
+    };
     const body: ProjectCreate = {
       name: value.name,
       scope_id: value.scope_id,
@@ -276,11 +310,12 @@ export class ProjectFormDialogComponent {
       ...(sd ? { start_date: sd } : {}),
       ...(ed ? { end_date: ed } : {}),
       ...(pubs ? { publications: pubs } : {}),
-      focal: value.focal != null ? Number(value.focal) : null,
-      resx: value.resx != null ? Number(value.resx) : null,
-      resy: value.resy != null ? Number(value.resy) : null,
-      pixel_x: value.pixel_x != null ? Number(value.pixel_x) : null,
-      pixel_y: value.pixel_y != null ? Number(value.pixel_y) : null
+      ...(rotation != null && Number.isFinite(rotation) ? { rotation } : {}),
+      focal: optNum(value.focal),
+      resx: optNum(value.resx),
+      resy: optNum(value.resy),
+      pixel_x: optNum(value.pixel_x),
+      pixel_y: optNum(value.pixel_y)
     };
     this.projectsService.createProject(body).subscribe({
       next: () => {

--- a/src/app/components/project-form-dialog/project-form-dialog.component.ts
+++ b/src/app/components/project-form-dialog/project-form-dialog.component.ts
@@ -11,9 +11,12 @@ import { ProjectCreate } from '../../models/project';
 import { MatSnackBar } from '@angular/material/snack-bar';
 import { CatalogsService, CatalogObject } from '../../services/catalogs.service';
 import { CoordsFormatterService } from '../../services/coords-formatter.service';
+import { TelescopeService } from '../../services/telescope.service';
 import { debounceTime, distinctUntilChanged } from 'rxjs/operators';
 import { finalize } from 'rxjs/operators';
 import { parseDecDegrees, parseRAHours } from '../../utils/coord-parse';
+import { computeFovDeg } from '../sky-view/sky-view.component';
+import { CommonModule } from '@angular/common';
 
 /** Longest-common-subsequence ratio, matching Python difflib.SequenceMatcher.ratio() semantics. */
 export function sequenceRatio(a: string, b: string): number {
@@ -73,6 +76,7 @@ export interface ProjectFormDialogData {
   styleUrls: ['./project-form-dialog.component.css'],
   standalone: true,
   imports: [
+    CommonModule,
     ReactiveFormsModule,
     MatDialogModule,
     MatFormFieldModule,
@@ -87,6 +91,7 @@ export class ProjectFormDialogComponent {
   private projectsService = inject(ProjectsService);
   private catalogsService = inject(CatalogsService);
   private coordsFormatter = inject(CoordsFormatterService);
+  private telescopeService = inject(TelescopeService);
   private dialogRef = inject(MatDialogRef<ProjectFormDialogComponent>);
   private snackBar = inject(MatSnackBar);
   data = inject<ProjectFormDialogData>(MAT_DIALOG_DATA);
@@ -94,6 +99,7 @@ export class ProjectFormDialogComponent {
   form: FormGroup;
   catalogLookupPending = false;
   similarProjects: SimilarProject[] = [];
+  fovLoadPending = false;
 
   constructor() {
     this.form = this.fb.group({
@@ -106,7 +112,12 @@ export class ProjectFormDialogComponent {
       active: [true],
       start_date: [''],
       end_date: [''],
-      publications: ['']
+      publications: [''],
+      focal: [null as number | null],
+      resx: [null as number | null],
+      resy: [null as number | null],
+      pixel_x: [null as number | null],
+      pixel_y: [null as number | null]
     });
 
     this.form.get('name')!.valueChanges.pipe(
@@ -118,6 +129,34 @@ export class ProjectFormDialogComponent {
         this.data?.existingProjects ?? []
       );
     });
+
+    this.form.get('scope_id')!.valueChanges.subscribe((scopeId: number | null) => {
+      if (!scopeId) return;
+      this.fovLoadPending = true;
+      this.telescopeService.getTelescope(scopeId).pipe(
+        finalize(() => { this.fovLoadPending = false; })
+      ).subscribe({
+        next: t => {
+          this.form.patchValue({
+            focal: t.focal ?? null,
+            resx: t.sensor?.resx ?? null,
+            resy: t.sensor?.resy ?? null,
+            pixel_x: t.sensor?.pixel_x ?? null,
+            pixel_y: t.sensor?.pixel_y ?? null
+          }, { emitEvent: false });
+        },
+        error: () => { /* leave fields as-is */ }
+      });
+    });
+  }
+
+  get fovChip(): string | null {
+    const v = this.form.getRawValue();
+    const { focal, resx, resy, pixel_x, pixel_y } = v;
+    if (!focal || !resx || !resy || !pixel_x || !pixel_y) return null;
+    const w = computeFovDeg(resx, pixel_x, focal);
+    const h = computeFovDeg(resy, pixel_y, focal);
+    return `${w.toFixed(2)}° × ${h.toFixed(2)}°`;
   }
 
   get scopes(): { scope_id: number; name: string }[] {
@@ -236,7 +275,12 @@ export class ProjectFormDialogComponent {
       decl,
       ...(sd ? { start_date: sd } : {}),
       ...(ed ? { end_date: ed } : {}),
-      ...(pubs ? { publications: pubs } : {})
+      ...(pubs ? { publications: pubs } : {}),
+      focal: value.focal != null ? Number(value.focal) : null,
+      resx: value.resx != null ? Number(value.resx) : null,
+      resy: value.resy != null ? Number(value.resy) : null,
+      pixel_x: value.pixel_x != null ? Number(value.pixel_x) : null,
+      pixel_y: value.pixel_y != null ? Number(value.pixel_y) : null
     };
     this.projectsService.createProject(body).subscribe({
       next: () => {

--- a/src/app/components/projects-list/projects-list.component.spec.ts
+++ b/src/app/components/projects-list/projects-list.component.spec.ts
@@ -20,6 +20,7 @@ function minimalTelescope(partial: Partial<Telescope> & Pick<Telescope, 'scope_i
     lat: null,
     alt: null,
     sensor: null,
+    default_rotation: null,
     ...partial
   };
 }

--- a/src/app/components/sky-map/sky-map.component.css
+++ b/src/app/components/sky-map/sky-map.component.css
@@ -1,24 +1,34 @@
 .sky-map-page {
-  padding: 16px;
-}
-
-.map-card {
-  max-width: 1200px;
-  margin: 0 auto;
+  position: relative;
+  padding: 0;
+  /* cancel the 20px margin-bottom that layout puts below mat-toolbar */
+  margin-top: -20px;
 }
 
 .aladin-host {
   width: 100%;
-  height: 600px;
+  /* 64px = mat-toolbar height */
+  height: calc(100vh - 64px);
   background: #000;
-  border-radius: 4px;
-  margin-top: 8px;
+  display: block;
+}
+
+.aladin-host.hidden {
+  display: none;
+}
+
+.scope-chips {
+  position: absolute;
+  top: 8px;
+  left: 8px;
+  z-index: 100;
 }
 
 .center-spinner {
   display: flex;
   justify-content: center;
-  padding: 40px;
+  align-items: center;
+  height: calc(100vh - 64px);
 }
 
 .error-msg {
@@ -26,14 +36,6 @@
   padding: 16px;
 }
 
-.scope-chips {
-  margin-bottom: 12px;
-}
-
 .chip-hidden {
   opacity: 0.4;
-}
-
-.aladin-host.hidden {
-  display: none;
 }

--- a/src/app/components/sky-map/sky-map.component.css
+++ b/src/app/components/sky-map/sky-map.component.css
@@ -1,0 +1,35 @@
+.sky-map-page {
+  padding: 16px;
+}
+
+.map-card {
+  max-width: 1200px;
+  margin: 0 auto;
+}
+
+.aladin-host {
+  width: 100%;
+  height: 600px;
+  background: #000;
+  border-radius: 4px;
+  margin-top: 8px;
+}
+
+.center-spinner {
+  display: flex;
+  justify-content: center;
+  padding: 40px;
+}
+
+.error-msg {
+  color: #f44336;
+  padding: 16px;
+}
+
+.scope-chips {
+  margin-bottom: 12px;
+}
+
+.chip-hidden {
+  opacity: 0.4;
+}

--- a/src/app/components/sky-map/sky-map.component.css
+++ b/src/app/components/sky-map/sky-map.component.css
@@ -33,3 +33,7 @@
 .chip-hidden {
   opacity: 0.4;
 }
+
+.aladin-host.hidden {
+  display: none;
+}

--- a/src/app/components/sky-map/sky-map.component.html
+++ b/src/app/components/sky-map/sky-map.component.html
@@ -1,0 +1,35 @@
+<div class="sky-map-page">
+  <mat-card class="map-card">
+    <mat-card-header>
+      <mat-card-title>All Projects — Sky Map</mat-card-title>
+    </mat-card-header>
+
+    <mat-card-content>
+      <div *ngIf="loading" class="center-spinner">
+        <mat-spinner diameter="48"></mat-spinner>
+      </div>
+
+      <div *ngIf="errorMsg" class="error-msg">{{ errorMsg }}</div>
+
+      <div *ngIf="!loading && !errorMsg">
+        <!-- Scope filter chips -->
+        <div class="scope-chips" *ngIf="scopeIds.length > 1">
+          <mat-chip-set>
+            <mat-chip
+              *ngFor="let id of scopeIds"
+              [style.--chip-color]="scopeColor(id)"
+              [class.chip-hidden]="!isScopeVisible(id)"
+              (click)="toggleScope(id)"
+              [highlighted]="isScopeVisible(id)">
+              <mat-icon matChipAvatar [style.color]="scopeColor(id)">lens</mat-icon>
+              Scope {{ id }}
+            </mat-chip>
+          </mat-chip-set>
+        </div>
+
+        <!-- Aladin host -->
+        <div #host class="aladin-host"></div>
+      </div>
+    </mat-card-content>
+  </mat-card>
+</div>

--- a/src/app/components/sky-map/sky-map.component.html
+++ b/src/app/components/sky-map/sky-map.component.html
@@ -33,10 +33,10 @@
             </mat-chip-set>
           </div>
         }
-
-        <!-- Aladin host -->
-        <div #host class="aladin-host"></div>
       }
+
+      <!-- Aladin host must always be in the DOM so ViewChild resolves on ngAfterViewInit -->
+      <div #host class="aladin-host" [class.hidden]="loading || !!errorMsg"></div>
     </mat-card-content>
   </mat-card>
 </div>

--- a/src/app/components/sky-map/sky-map.component.html
+++ b/src/app/components/sky-map/sky-map.component.html
@@ -5,31 +5,38 @@
     </mat-card-header>
 
     <mat-card-content>
-      <div *ngIf="loading" class="center-spinner">
-        <mat-spinner diameter="48"></mat-spinner>
-      </div>
-
-      <div *ngIf="errorMsg" class="error-msg">{{ errorMsg }}</div>
-
-      <div *ngIf="!loading && !errorMsg">
-        <!-- Scope filter chips -->
-        <div class="scope-chips" *ngIf="scopeIds.length > 1">
-          <mat-chip-set>
-            <mat-chip
-              *ngFor="let id of scopeIds"
-              [style.--chip-color]="scopeColor(id)"
-              [class.chip-hidden]="!isScopeVisible(id)"
-              (click)="toggleScope(id)"
-              [highlighted]="isScopeVisible(id)">
-              <mat-icon matChipAvatar [style.color]="scopeColor(id)">lens</mat-icon>
-              Scope {{ id }}
-            </mat-chip>
-          </mat-chip-set>
+      @if (loading) {
+        <div class="center-spinner">
+          <mat-spinner diameter="48"></mat-spinner>
         </div>
+      }
+
+      @if (errorMsg) {
+        <div class="error-msg">{{ errorMsg }}</div>
+      }
+
+      @if (!loading && !errorMsg) {
+        <!-- Scope filter chips -->
+        @if (scopeIds.length > 1) {
+          <div class="scope-chips">
+            <mat-chip-set>
+              @for (id of scopeIds; track id) {
+                <mat-chip
+                  [style.--chip-color]="scopeColor(id)"
+                  [class.chip-hidden]="!isScopeVisible(id)"
+                  (click)="toggleScope(id)"
+                  [highlighted]="isScopeVisible(id)">
+                  <mat-icon matChipAvatar [style.color]="scopeColor(id)">lens</mat-icon>
+                  Scope {{ id }}
+                </mat-chip>
+              }
+            </mat-chip-set>
+          </div>
+        }
 
         <!-- Aladin host -->
         <div #host class="aladin-host"></div>
-      </div>
+      }
     </mat-card-content>
   </mat-card>
 </div>

--- a/src/app/components/sky-map/sky-map.component.html
+++ b/src/app/components/sky-map/sky-map.component.html
@@ -1,42 +1,31 @@
 <div class="sky-map-page">
-  <mat-card class="map-card">
-    <mat-card-header>
-      <mat-card-title>All Projects — Sky Map</mat-card-title>
-    </mat-card-header>
+  @if (loading) {
+    <div class="center-spinner">
+      <mat-spinner diameter="48"></mat-spinner>
+    </div>
+  }
 
-    <mat-card-content>
-      @if (loading) {
-        <div class="center-spinner">
-          <mat-spinner diameter="48"></mat-spinner>
-        </div>
-      }
+  @if (errorMsg) {
+    <div class="error-msg">{{ errorMsg }}</div>
+  }
 
-      @if (errorMsg) {
-        <div class="error-msg">{{ errorMsg }}</div>
-      }
-
-      @if (!loading && !errorMsg) {
-        <!-- Scope filter chips -->
-        @if (scopeIds.length > 1) {
-          <div class="scope-chips">
-            <mat-chip-set>
-              @for (id of scopeIds; track id) {
-                <mat-chip
-                  [style.--chip-color]="scopeColor(id)"
-                  [class.chip-hidden]="!isScopeVisible(id)"
-                  (click)="toggleScope(id)"
-                  [highlighted]="isScopeVisible(id)">
-                  <mat-icon matChipAvatar [style.color]="scopeColor(id)">lens</mat-icon>
-                  Scope {{ id }}
-                </mat-chip>
-              }
-            </mat-chip-set>
-          </div>
+  @if (!loading && !errorMsg && scopeIds.length > 1) {
+    <div class="scope-chips">
+      <mat-chip-set>
+        @for (id of scopeIds; track id) {
+          <mat-chip
+            [style.--chip-color]="scopeColor(id)"
+            [class.chip-hidden]="!isScopeVisible(id)"
+            (click)="toggleScope(id)"
+            [highlighted]="isScopeVisible(id)">
+            <mat-icon matChipAvatar [style.color]="scopeColor(id)">lens</mat-icon>
+            Scope {{ id }}
+          </mat-chip>
         }
-      }
+      </mat-chip-set>
+    </div>
+  }
 
-      <!-- Aladin host must always be in the DOM so ViewChild resolves on ngAfterViewInit -->
-      <div #host class="aladin-host" [class.hidden]="loading || !!errorMsg"></div>
-    </mat-card-content>
-  </mat-card>
+  <!-- Aladin host must always be in the DOM so ViewChild resolves on ngAfterViewInit -->
+  <div #host class="aladin-host" [class.hidden]="loading || !!errorMsg"></div>
 </div>

--- a/src/app/components/sky-map/sky-map.component.spec.ts
+++ b/src/app/components/sky-map/sky-map.component.spec.ts
@@ -46,7 +46,7 @@ describe('SkyMapComponent', () => {
   });
 
   it('loads projects on init', () => {
-    expect(projectsService.getProjects).toHaveBeenCalledWith({ per_page: 1000 });
+    expect(projectsService.getProjects).toHaveBeenCalledWith({ per_page: 1000, page: 1 });
     expect(component.projects.length).toBe(2);
     expect(component.loading).toBe(false);
   });
@@ -82,5 +82,32 @@ describe('SkyMapComponent', () => {
     errFixture.detectChanges();
     expect(errFixture.componentInstance.errorMsg).toBe('Failed to load projects');
     expect(errFixture.componentInstance.loading).toBe(false);
+  });
+
+  it('loads additional pages when total exceeds per_page', async () => {
+    const page1 = {
+      projects: [makeProject()],
+      total: 2, page: 1, per_page: 1000, pages: 2
+    };
+    const page2 = {
+      projects: [makeProject({ project_id: 2, scope_id: 2, name: 'M42' })],
+      total: 2, page: 2, per_page: 1000, pages: 2
+    };
+    const multiPageService = {
+      getProjects: vi.fn()
+        .mockReturnValueOnce(of(page1))
+        .mockReturnValueOnce(of(page2))
+    };
+    await TestBed.resetTestingModule();
+    await TestBed.configureTestingModule({
+      imports: [SkyMapComponent, NoopAnimationsModule],
+      providers: [{ provide: ProjectsService, useValue: multiPageService }]
+    }).compileComponents();
+    const multiFixture = TestBed.createComponent(SkyMapComponent);
+    multiFixture.detectChanges();
+    expect(multiPageService.getProjects).toHaveBeenCalledTimes(2);
+    expect(multiPageService.getProjects).toHaveBeenNthCalledWith(1, { per_page: 1000, page: 1 });
+    expect(multiPageService.getProjects).toHaveBeenNthCalledWith(2, { per_page: 1000, page: 2 });
+    expect(multiFixture.componentInstance.projects.length).toBe(2);
   });
 });

--- a/src/app/components/sky-map/sky-map.component.spec.ts
+++ b/src/app/components/sky-map/sky-map.component.spec.ts
@@ -1,0 +1,86 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { of, throwError } from 'rxjs';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+import { ProjectsService } from '../../services/projects.service';
+import { SkyMapComponent } from './sky-map.component';
+import { Project } from '../../models/project';
+
+function makeProject(overrides: Partial<Project> = {}): Project {
+  return {
+    project_id: 1,
+    name: 'M31',
+    scope_id: 1,
+    active: true,
+    ra: 10.68,
+    decl: 41.27,
+    focal: 2541,
+    resx: 3326,
+    resy: 2504,
+    pixel_x: 5.4,
+    pixel_y: 5.4,
+    ...overrides
+  };
+}
+
+describe('SkyMapComponent', () => {
+  let component: SkyMapComponent;
+  let fixture: ComponentFixture<SkyMapComponent>;
+  let projectsService: { getProjects: ReturnType<typeof vi.fn> };
+
+  beforeEach(async () => {
+    projectsService = {
+      getProjects: vi.fn().mockReturnValue(of({
+        projects: [makeProject(), makeProject({ project_id: 2, scope_id: 2, name: 'M42' })],
+        total: 2, page: 1, per_page: 1000, pages: 1
+      }))
+    };
+
+    await TestBed.configureTestingModule({
+      imports: [SkyMapComponent, NoopAnimationsModule],
+      providers: [{ provide: ProjectsService, useValue: projectsService }]
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(SkyMapComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('loads projects on init', () => {
+    expect(projectsService.getProjects).toHaveBeenCalledWith({ per_page: 1000 });
+    expect(component.projects.length).toBe(2);
+    expect(component.loading).toBe(false);
+  });
+
+  it('derives unique sorted scope IDs', () => {
+    expect(component.scopeIds).toEqual([1, 2]);
+  });
+
+  it('all scopes visible by default', () => {
+    expect(component.isScopeVisible(1)).toBe(true);
+    expect(component.isScopeVisible(2)).toBe(true);
+  });
+
+  it('toggleScope hides and restores a scope', () => {
+    component.toggleScope(1);
+    expect(component.isScopeVisible(1)).toBe(false);
+    component.toggleScope(1);
+    expect(component.isScopeVisible(1)).toBe(true);
+  });
+
+  it('scopeColor returns a hex color string', () => {
+    expect(component.scopeColor(0)).toMatch(/^#[0-9a-f]{6}$/i);
+  });
+
+  it('sets errorMsg on load failure', async () => {
+    const errorService = { getProjects: vi.fn().mockReturnValue(throwError(() => new Error('fail'))) };
+    await TestBed.resetTestingModule();
+    await TestBed.configureTestingModule({
+      imports: [SkyMapComponent, NoopAnimationsModule],
+      providers: [{ provide: ProjectsService, useValue: errorService }]
+    }).compileComponents();
+    const errFixture = TestBed.createComponent(SkyMapComponent);
+    errFixture.detectChanges();
+    expect(errFixture.componentInstance.errorMsg).toBe('Failed to load projects');
+    expect(errFixture.componentInstance.loading).toBe(false);
+  });
+});

--- a/src/app/components/sky-map/sky-map.component.ts
+++ b/src/app/components/sky-map/sky-map.component.ts
@@ -1,0 +1,175 @@
+import {
+  Component,
+  OnInit,
+  OnDestroy,
+  AfterViewInit,
+  ElementRef,
+  ViewChild,
+  inject,
+  NgZone
+} from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { RouterModule } from '@angular/router';
+import { MatCardModule } from '@angular/material/card';
+import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
+import { MatChipsModule } from '@angular/material/chips';
+import { MatIconModule } from '@angular/material/icon';
+import { ProjectsService } from '../../services/projects.service';
+import { Project } from '../../models/project';
+import { computeFovDeg } from '../sky-view/sky-view.component';
+
+/** PALETTE — one hue per scope_id (cycles). */
+const SCOPE_COLORS = [
+  '#4fc3f7', '#81c784', '#ffb74d', '#f06292',
+  '#ba68c8', '#4dd0e1', '#aed581', '#ff8a65'
+];
+
+function scopeColor(scopeId: number): string {
+  return SCOPE_COLORS[scopeId % SCOPE_COLORS.length];
+}
+
+function fovCorners(
+  ra: number, dec: number,
+  wDeg: number, hDeg: number,
+  rotDeg: number
+): [number, number][] {
+  const rotRad = (rotDeg * Math.PI) / 180;
+  const hw = wDeg / 2, hh = hDeg / 2;
+  const cosD = Math.cos((dec * Math.PI) / 180);
+  return ([[-hw, -hh], [hw, -hh], [hw, hh], [-hw, hh]] as [number, number][]).map(([dx, dy]) => [
+    ra + (dx * Math.cos(rotRad) + dy * Math.sin(rotRad)) / cosD,
+    dec + (-dx * Math.sin(rotRad) + dy * Math.cos(rotRad))
+  ]);
+}
+
+@Component({
+  selector: 'app-sky-map',
+  standalone: true,
+  imports: [
+    CommonModule,
+    RouterModule,
+    MatCardModule,
+    MatProgressSpinnerModule,
+    MatChipsModule,
+    MatIconModule
+  ],
+  templateUrl: './sky-map.component.html',
+  styleUrls: ['./sky-map.component.css']
+})
+export class SkyMapComponent implements OnInit, AfterViewInit, OnDestroy {
+  @ViewChild('host', { static: true }) hostEl!: ElementRef<HTMLDivElement>;
+
+  private projectsService = inject(ProjectsService);
+  private zone = inject(NgZone);
+
+  projects: Project[] = [];
+  loading = true;
+  errorMsg: string | null = null;
+  hiddenScopes = new Set<number>();
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  private A: any = null;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  private aladin: any = null;
+  private aladinReady = false;
+  private projectsReady = false;
+
+  get scopeIds(): number[] {
+    return [...new Set(this.projects.map(p => p.scope_id))].sort((a, b) => a - b);
+  }
+
+  scopeColor(id: number): string { return scopeColor(id); }
+
+  isScopeVisible(id: number): boolean { return !this.hiddenScopes.has(id); }
+
+  toggleScope(id: number): void {
+    if (this.hiddenScopes.has(id)) {
+      this.hiddenScopes.delete(id);
+    } else {
+      this.hiddenScopes.add(id);
+    }
+    this.redrawAll();
+  }
+
+  ngOnInit(): void {
+    this.projectsService.getProjects({ per_page: 1000 }).subscribe({
+      next: res => {
+        this.projects = (res.projects ?? []).filter(p => p.active);
+        this.loading = false;
+        this.projectsReady = true;
+        this.maybeRender();
+      },
+      error: () => {
+        this.errorMsg = 'Failed to load projects';
+        this.loading = false;
+      }
+    });
+  }
+
+  ngAfterViewInit(): void {
+    this.zone.runOutsideAngular(() => {
+      import('aladin-lite').then((mod) => {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        this.A = (mod as any).default ?? mod;
+        this.aladin = this.A.aladin(this.hostEl.nativeElement, {
+          survey: 'P/DSS2/color',
+          fov: 180,
+          target: '180 0',
+          projection: 'AIT',
+          showReticle: true,
+          showZoomControl: true,
+          showFullscreenControl: false,
+          showLayersControl: true,
+          showGotoControl: true,
+          showShareControl: false,
+          cooFrame: 'ICRS'
+        });
+        this.aladinReady = true;
+        this.maybeRender();
+      });
+    });
+  }
+
+  ngOnDestroy(): void {
+    this.aladin = null;
+    this.A = null;
+  }
+
+  private maybeRender(): void {
+    if (this.aladinReady && this.projectsReady) {
+      this.zone.runOutsideAngular(() => this.redrawAll());
+    }
+  }
+
+  private redrawAll(): void {
+    if (!this.aladin || !this.A) return;
+    try {
+      this.aladin.removeLayers();
+    } catch { /* ignore */ }
+
+    for (const p of this.projects) {
+      if (this.hiddenScopes.has(p.scope_id)) continue;
+      if (p.ra == null || p.decl == null) continue;
+      const color = scopeColor(p.scope_id);
+      const hasFov = p.focal && p.resx && p.resy && p.pixel_x && p.pixel_y;
+
+      if (hasFov) {
+        const wDeg = computeFovDeg(p.resx!, p.pixel_x!, p.focal!);
+        const hDeg = computeFovDeg(p.resy!, p.pixel_y!, p.focal!);
+        const corners = fovCorners(p.ra, p.decl, wDeg, hDeg, p.rotation ?? 0);
+        try {
+          const overlay = this.A.graphicOverlay({ color, lineWidth: 1.5 });
+          this.aladin.addLayer(overlay);
+          overlay.add(this.A.polygon(corners));
+        } catch { /* overlay API may vary */ }
+      } else {
+        // No optical params — show a marker only
+        try {
+          const cat = this.A.catalog({ name: p.name, sourceSize: 12, color });
+          this.aladin.addLayer(cat);
+          cat.addSources([this.A.source(p.ra, p.decl, { name: p.name })]);
+        } catch { /* ignore */ }
+      }
+    }
+  }
+}

--- a/src/app/components/sky-map/sky-map.component.ts
+++ b/src/app/components/sky-map/sky-map.component.ts
@@ -10,7 +10,6 @@ import {
 } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { RouterModule } from '@angular/router';
-import { MatCardModule } from '@angular/material/card';
 import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
 import { MatChipsModule } from '@angular/material/chips';
 import { MatIconModule } from '@angular/material/icon';
@@ -48,7 +47,6 @@ function fovCorners(
   imports: [
     CommonModule,
     RouterModule,
-    MatCardModule,
     MatProgressSpinnerModule,
     MatChipsModule,
     MatIconModule

--- a/src/app/components/sky-map/sky-map.component.ts
+++ b/src/app/components/sky-map/sky-map.component.ts
@@ -144,33 +144,50 @@ export class SkyMapComponent implements OnInit, AfterViewInit, OnDestroy {
 
   private redrawAll(): void {
     if (!this.aladin || !this.A) return;
-    // v3 has removeOverlays() for graphic overlays and no single "remove all" for catalogs;
-    // re-create the aladin view is the safest reset — falling back to individual removes.
     try { this.aladin.removeOverlays(); } catch { /* ignore */ }
     try { this.aladin.removeCatalogs(); } catch { /* ignore */ }
+
+    // One catalog and one overlay per scope_id so they appear as a single named layer.
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const catalogs = new Map<number, any>();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const overlays = new Map<number, any>();
 
     for (const p of this.projects) {
       if (this.hiddenScopes.has(p.scope_id)) continue;
       if (p.ra == null || p.decl == null) continue;
+
       const color = scopeColor(p.scope_id);
       // API stores RA in hours; Aladin Lite expects degrees
       const raDeg = p.ra * 15;
       const hasFov = p.focal && p.resx && p.resy && p.pixel_x && p.pixel_y;
 
       if (hasFov) {
+        if (!overlays.has(p.scope_id)) {
+          const ov = this.A.graphicOverlay({ name: `Scope ${p.scope_id}`, color, lineWidth: 1.5 });
+          this.aladin.addOverlay(ov);
+          overlays.set(p.scope_id, ov);
+        }
         const wDeg = computeFovDeg(p.resx!, p.pixel_x!, p.focal!);
         const hDeg = computeFovDeg(p.resy!, p.pixel_y!, p.focal!);
         const corners = fovCorners(raDeg, p.decl, wDeg, hDeg, p.rotation ?? 0);
-        try {
-          const overlay = this.A.graphicOverlay({ color, lineWidth: 1.5 });
-          this.aladin.addOverlay(overlay);
-          overlay.add(this.A.polygon(corners));
-        } catch { /* ignore */ }
+        try { overlays.get(p.scope_id).add(this.A.polygon(corners)); } catch { /* ignore */ }
       } else {
-        try {
-          const cat = this.A.catalog({ name: p.name, sourceSize: 12, color });
+        if (!catalogs.has(p.scope_id)) {
+          const cat = this.A.catalog({
+            name: `Scope ${p.scope_id}`,
+            sourceSize: 12,
+            color,
+            onClick: 'showPopup',
+            hoverColor: '#ffffff',
+          });
           this.aladin.addCatalog(cat);
-          cat.addSources([this.A.source(raDeg, p.decl, { name: p.name })]);
+          catalogs.set(p.scope_id, cat);
+        }
+        try {
+          catalogs.get(p.scope_id).addSources([
+            this.A.source(raDeg, p.decl, { popupTitle: p.name, popupDesc: `Scope ${p.scope_id}` })
+          ]);
         } catch { /* ignore */ }
       }
     }

--- a/src/app/components/sky-map/sky-map.component.ts
+++ b/src/app/components/sky-map/sky-map.component.ts
@@ -8,14 +8,15 @@ import {
   inject,
   NgZone
 } from '@angular/core';
-import { CommonModule } from '@angular/common';
 import { RouterModule } from '@angular/router';
 import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
 import { MatChipsModule } from '@angular/material/chips';
 import { MatIconModule } from '@angular/material/icon';
+import { EMPTY, Subject } from 'rxjs';
+import { expand, reduce, takeUntil } from 'rxjs/operators';
 import { ProjectsService } from '../../services/projects.service';
 import { Project } from '../../models/project';
-import { computeFovDeg } from '../sky-view/sky-view.component';
+import { computeFovDeg, fovCorners, raHoursToDegrees } from '../../utils/fov';
 
 /** PALETTE — one hue per scope_id (cycles). */
 const SCOPE_COLORS = [
@@ -23,29 +24,16 @@ const SCOPE_COLORS = [
   '#ba68c8', '#4dd0e1', '#aed581', '#ff8a65'
 ];
 
+const PAGE_SIZE = 1000;
+
 function scopeColor(scopeId: number): string {
   return SCOPE_COLORS[scopeId % SCOPE_COLORS.length];
-}
-
-function fovCorners(
-  ra: number, dec: number,
-  wDeg: number, hDeg: number,
-  rotDeg: number
-): [number, number][] {
-  const rotRad = (rotDeg * Math.PI) / 180;
-  const hw = wDeg / 2, hh = hDeg / 2;
-  const cosD = Math.cos((dec * Math.PI) / 180);
-  return ([[-hw, -hh], [hw, -hh], [hw, hh], [-hw, hh]] as [number, number][]).map(([dx, dy]) => [
-    ra + (dx * Math.cos(rotRad) + dy * Math.sin(rotRad)) / cosD,
-    dec + (-dx * Math.sin(rotRad) + dy * Math.cos(rotRad))
-  ]);
 }
 
 @Component({
   selector: 'app-sky-map',
   standalone: true,
   imports: [
-    CommonModule,
     RouterModule,
     MatProgressSpinnerModule,
     MatChipsModule,
@@ -59,6 +47,7 @@ export class SkyMapComponent implements OnInit, AfterViewInit, OnDestroy {
 
   private projectsService = inject(ProjectsService);
   private zone = inject(NgZone);
+  private destroy$ = new Subject<void>();
 
   projects: Project[] = [];
   loading = true;
@@ -71,6 +60,7 @@ export class SkyMapComponent implements OnInit, AfterViewInit, OnDestroy {
   private aladin: any = null;
   private aladinReady = false;
   private projectsReady = false;
+  private destroyed = false;
 
   get scopeIds(): number[] {
     return [...new Set(this.projects.map(p => p.scope_id))].sort((a, b) => a - b);
@@ -90,9 +80,17 @@ export class SkyMapComponent implements OnInit, AfterViewInit, OnDestroy {
   }
 
   ngOnInit(): void {
-    this.projectsService.getProjects({ per_page: 1000 }).subscribe({
-      next: res => {
-        this.projects = (res.projects ?? []).filter(p => p.active);
+    this.projectsService.getProjects({ per_page: PAGE_SIZE, page: 1 }).pipe(
+      expand(res =>
+        res.page < (res.pages ?? 1)
+          ? this.projectsService.getProjects({ per_page: PAGE_SIZE, page: res.page + 1 })
+          : EMPTY
+      ),
+      reduce((acc, res) => acc.concat(res.projects ?? []), [] as Project[]),
+      takeUntil(this.destroy$)
+    ).subscribe({
+      next: all => {
+        this.projects = all.filter(p => p.active);
         this.loading = false;
         this.projectsReady = true;
         this.maybeRender();
@@ -107,10 +105,12 @@ export class SkyMapComponent implements OnInit, AfterViewInit, OnDestroy {
   ngAfterViewInit(): void {
     this.zone.runOutsideAngular(() => {
       import('aladin-lite').then((mod) => {
+        if (this.destroyed) return;
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         this.A = (mod as any).default ?? mod;
         // A.init resolves once the WASM backend is ready (aladin-lite v3 requirement)
-        this.A.init.then(() => {
+        Promise.resolve(this.A.init).then(() => {
+          if (this.destroyed || !this.hostEl?.nativeElement) return;
           this.aladin = this.A.aladin(this.hostEl.nativeElement, {
             survey: 'https://alasky.cds.unistra.fr/DSS/DSScolor',
             fov: 180,
@@ -132,8 +132,12 @@ export class SkyMapComponent implements OnInit, AfterViewInit, OnDestroy {
   }
 
   ngOnDestroy(): void {
-    this.aladin = null;
+    this.destroyed = true;
+    this.destroy$.next();
+    this.destroy$.complete();
+    this.destroyAladin();
     this.A = null;
+    this.aladinReady = false;
   }
 
   private maybeRender(): void {
@@ -159,12 +163,30 @@ export class SkyMapComponent implements OnInit, AfterViewInit, OnDestroy {
 
       const color = scopeColor(p.scope_id);
       // API stores RA in hours; Aladin Lite expects degrees
-      const raDeg = p.ra * 15;
-      const hasFov = p.focal && p.resx && p.resy && p.pixel_x && p.pixel_y;
+      const raDeg = raHoursToDegrees(p.ra);
+      const hasFov = !!(p.focal && p.resx && p.resy && p.pixel_x && p.pixel_y);
+
+      // Always add a catalog marker so projects (including FOV ones) are identifiable.
+      if (!catalogs.has(p.scope_id)) {
+        const cat = this.A.catalog({
+          name: `Scope ${p.scope_id}`,
+          sourceSize: 12,
+          color,
+          onClick: 'showPopup',
+          hoverColor: '#ffffff',
+        });
+        this.aladin.addCatalog(cat);
+        catalogs.set(p.scope_id, cat);
+      }
+      try {
+        catalogs.get(p.scope_id).addSources([
+          this.A.source(raDeg, p.decl, { popupTitle: p.name, popupDesc: `Scope ${p.scope_id}` })
+        ]);
+      } catch { /* ignore */ }
 
       if (hasFov) {
         if (!overlays.has(p.scope_id)) {
-          const ov = this.A.graphicOverlay({ name: `Scope ${p.scope_id}`, color, lineWidth: 1.5 });
+          const ov = this.A.graphicOverlay({ name: `Scope ${p.scope_id} FOV`, color, lineWidth: 1.5 });
           this.aladin.addOverlay(ov);
           overlays.set(p.scope_id, ov);
         }
@@ -172,24 +194,19 @@ export class SkyMapComponent implements OnInit, AfterViewInit, OnDestroy {
         const hDeg = computeFovDeg(p.resy!, p.pixel_y!, p.focal!);
         const corners = fovCorners(raDeg, p.decl, wDeg, hDeg, p.rotation ?? 0);
         try { overlays.get(p.scope_id).add(this.A.polygon(corners)); } catch { /* ignore */ }
-      } else {
-        if (!catalogs.has(p.scope_id)) {
-          const cat = this.A.catalog({
-            name: `Scope ${p.scope_id}`,
-            sourceSize: 12,
-            color,
-            onClick: 'showPopup',
-            hoverColor: '#ffffff',
-          });
-          this.aladin.addCatalog(cat);
-          catalogs.set(p.scope_id, cat);
-        }
-        try {
-          catalogs.get(p.scope_id).addSources([
-            this.A.source(raDeg, p.decl, { popupTitle: p.name, popupDesc: `Scope ${p.scope_id}` })
-          ]);
-        } catch { /* ignore */ }
       }
     }
+  }
+
+  private destroyAladin(): void {
+    try {
+      this.aladin?.remove?.();
+    } catch {
+      /* ignore */
+    }
+    if (this.hostEl?.nativeElement) {
+      this.hostEl.nativeElement.innerHTML = '';
+    }
+    this.aladin = null;
   }
 }

--- a/src/app/components/sky-map/sky-map.component.ts
+++ b/src/app/components/sky-map/sky-map.component.ts
@@ -144,31 +144,33 @@ export class SkyMapComponent implements OnInit, AfterViewInit, OnDestroy {
 
   private redrawAll(): void {
     if (!this.aladin || !this.A) return;
-    try {
-      this.aladin.removeLayers();
-    } catch { /* ignore */ }
+    // v3 has removeOverlays() for graphic overlays and no single "remove all" for catalogs;
+    // re-create the aladin view is the safest reset — falling back to individual removes.
+    try { this.aladin.removeOverlays(); } catch { /* ignore */ }
+    try { this.aladin.removeCatalogs(); } catch { /* ignore */ }
 
     for (const p of this.projects) {
       if (this.hiddenScopes.has(p.scope_id)) continue;
       if (p.ra == null || p.decl == null) continue;
       const color = scopeColor(p.scope_id);
+      // API stores RA in hours; Aladin Lite expects degrees
+      const raDeg = p.ra * 15;
       const hasFov = p.focal && p.resx && p.resy && p.pixel_x && p.pixel_y;
 
       if (hasFov) {
         const wDeg = computeFovDeg(p.resx!, p.pixel_x!, p.focal!);
         const hDeg = computeFovDeg(p.resy!, p.pixel_y!, p.focal!);
-        const corners = fovCorners(p.ra, p.decl, wDeg, hDeg, p.rotation ?? 0);
+        const corners = fovCorners(raDeg, p.decl, wDeg, hDeg, p.rotation ?? 0);
         try {
           const overlay = this.A.graphicOverlay({ color, lineWidth: 1.5 });
-          this.aladin.addLayer(overlay);
+          this.aladin.addOverlay(overlay);
           overlay.add(this.A.polygon(corners));
-        } catch { /* overlay API may vary */ }
+        } catch { /* ignore */ }
       } else {
-        // No optical params — show a marker only
         try {
           const cat = this.A.catalog({ name: p.name, sourceSize: 12, color });
-          this.aladin.addLayer(cat);
-          cat.addSources([this.A.source(p.ra, p.decl, { name: p.name })]);
+          this.aladin.addCatalog(cat);
+          cat.addSources([this.A.source(raDeg, p.decl, { name: p.name })]);
         } catch { /* ignore */ }
       }
     }

--- a/src/app/components/sky-map/sky-map.component.ts
+++ b/src/app/components/sky-map/sky-map.component.ts
@@ -111,21 +111,24 @@ export class SkyMapComponent implements OnInit, AfterViewInit, OnDestroy {
       import('aladin-lite').then((mod) => {
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         this.A = (mod as any).default ?? mod;
-        this.aladin = this.A.aladin(this.hostEl.nativeElement, {
-          survey: 'P/DSS2/color',
-          fov: 180,
-          target: '180 0',
-          projection: 'AIT',
-          showReticle: true,
-          showZoomControl: true,
-          showFullscreenControl: false,
-          showLayersControl: true,
-          showGotoControl: true,
-          showShareControl: false,
-          cooFrame: 'ICRS'
+        // A.init resolves once the WASM backend is ready (aladin-lite v3 requirement)
+        this.A.init.then(() => {
+          this.aladin = this.A.aladin(this.hostEl.nativeElement, {
+            survey: 'https://alasky.cds.unistra.fr/DSS/DSScolor',
+            fov: 180,
+            target: '180 0',
+            projection: 'AIT',
+            showReticle: true,
+            showZoomControl: true,
+            showFullscreenControl: false,
+            showLayersControl: true,
+            showGotoControl: true,
+            showShareControl: false,
+            cooFrame: 'ICRS'
+          });
+          this.aladinReady = true;
+          this.maybeRender();
         });
-        this.aladinReady = true;
-        this.maybeRender();
       });
     });
   }

--- a/src/app/components/sky-view/sky-view.component.spec.ts
+++ b/src/app/components/sky-view/sky-view.component.spec.ts
@@ -1,0 +1,32 @@
+import { computeFovDeg } from './sky-view.component';
+
+describe('computeFovDeg', () => {
+  it('computes correct FOV for a known setup', () => {
+    // QSI 583ws: 3326 px × 5.4 µm, focal 2541 mm
+    // = 2 * atan((3326 * 5.4/1000) / (2 * 2541)) * (180/π) ≈ 0.405°
+    const fov = computeFovDeg(3326, 5.4, 2541);
+    expect(fov).toBeCloseTo(0.405, 2);
+  });
+
+  it('is symmetric: swapping pixels and focal scales proportionally', () => {
+    const a = computeFovDeg(1000, 5, 500);
+    const b = computeFovDeg(2000, 5, 1000);
+    expect(a).toBeCloseTo(b, 6);
+  });
+
+  it('returns a positive value for valid inputs', () => {
+    expect(computeFovDeg(1000, 5, 500)).toBeGreaterThan(0);
+  });
+
+  it('increases with sensor size', () => {
+    const small = computeFovDeg(1000, 5, 1000);
+    const large = computeFovDeg(2000, 5, 1000);
+    expect(large).toBeGreaterThan(small);
+  });
+
+  it('decreases with longer focal length', () => {
+    const wide = computeFovDeg(1000, 5, 500);
+    const narrow = computeFovDeg(1000, 5, 2000);
+    expect(narrow).toBeLessThan(wide);
+  });
+});

--- a/src/app/components/sky-view/sky-view.component.spec.ts
+++ b/src/app/components/sky-view/sky-view.component.spec.ts
@@ -1,32 +1,9 @@
-import { computeFovDeg } from './sky-view.component';
+// FOV math lives in utils/fov; re-export coverage is in fov.spec.ts.
+// This file keeps the previous import path from breaking older runners.
+import { computeFovDeg } from '../../utils/fov';
 
-describe('computeFovDeg', () => {
-  it('computes correct FOV for a known setup', () => {
-    // QSI 583ws: 3326 px × 5.4 µm, focal 2541 mm
-    // = 2 * atan((3326 * 5.4/1000) / (2 * 2541)) * (180/π) ≈ 0.405°
-    const fov = computeFovDeg(3326, 5.4, 2541);
-    expect(fov).toBeCloseTo(0.405, 2);
-  });
-
-  it('is symmetric: swapping pixels and focal scales proportionally', () => {
-    const a = computeFovDeg(1000, 5, 500);
-    const b = computeFovDeg(2000, 5, 1000);
-    expect(a).toBeCloseTo(b, 6);
-  });
-
-  it('returns a positive value for valid inputs', () => {
+describe('SkyViewComponent (re-export)', () => {
+  it('computeFovDeg is available via utils', () => {
     expect(computeFovDeg(1000, 5, 500)).toBeGreaterThan(0);
-  });
-
-  it('increases with sensor size', () => {
-    const small = computeFovDeg(1000, 5, 1000);
-    const large = computeFovDeg(2000, 5, 1000);
-    expect(large).toBeGreaterThan(small);
-  });
-
-  it('decreases with longer focal length', () => {
-    const wide = computeFovDeg(1000, 5, 500);
-    const narrow = computeFovDeg(1000, 5, 2000);
-    expect(narrow).toBeLessThan(wide);
   });
 });

--- a/src/app/components/sky-view/sky-view.component.ts
+++ b/src/app/components/sky-view/sky-view.component.ts
@@ -6,7 +6,8 @@ import {
   AfterViewInit,
   ElementRef,
   ViewChild,
-  NgZone
+  NgZone,
+  inject
 } from '@angular/core';
 
 /** FOV rectangle corners in WCS space for an Aladin polygon overlay. */
@@ -58,8 +59,7 @@ export class SkyViewComponent implements AfterViewInit, OnChanges, OnDestroy {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   private aladin: any = null;
   private ready = false;
-
-  constructor(private zone: NgZone) {}
+  private zone = inject(NgZone);
 
   ngAfterViewInit(): void {
     this.zone.runOutsideAngular(() => {

--- a/src/app/components/sky-view/sky-view.component.ts
+++ b/src/app/components/sky-view/sky-view.component.ts
@@ -1,0 +1,122 @@
+import {
+  Component,
+  Input,
+  OnChanges,
+  OnDestroy,
+  AfterViewInit,
+  ElementRef,
+  ViewChild,
+  NgZone
+} from '@angular/core';
+
+/** FOV rectangle corners in WCS space for an Aladin polygon overlay. */
+function fovCorners(
+  ra: number, dec: number,
+  wDeg: number, hDeg: number,
+  rotDeg: number
+): [number, number][] {
+  const rotRad = (rotDeg * Math.PI) / 180;
+  const hw = wDeg / 2;
+  const hh = hDeg / 2;
+  const cosD = Math.cos((dec * Math.PI) / 180);
+  return (
+    [[-hw, -hh], [hw, -hh], [hw, hh], [-hw, hh]] as [number, number][]
+  ).map(([dx, dy]) => [
+    ra + (dx * Math.cos(rotRad) + dy * Math.sin(rotRad)) / cosD,
+    dec + (-dx * Math.sin(rotRad) + dy * Math.cos(rotRad))
+  ]);
+}
+
+/** Compute FOV dimension in degrees from sensor geometry. */
+export function computeFovDeg(pixels: number, pixelMicron: number, focalMm: number): number {
+  return 2 * Math.atan((pixels * pixelMicron / 1000) / (2 * focalMm)) * (180 / Math.PI);
+}
+
+@Component({
+  selector: 'app-sky-view',
+  standalone: true,
+  template: `<div #host class="aladin-host"></div>`,
+  styles: [`
+    :host { display: block; }
+    .aladin-host { width: 100%; height: 400px; background: #000; border-radius: 4px; }
+  `]
+})
+export class SkyViewComponent implements AfterViewInit, OnChanges, OnDestroy {
+  @Input() ra!: number;
+  @Input() dec!: number;
+  @Input() fovWidthDeg!: number;
+  @Input() fovHeightDeg!: number;
+  /** Camera position angle, degrees East of North. */
+  @Input() rotation = 0;
+  /** How many FOV widths the sky view should span. */
+  @Input() fovMultiplier = 3;
+
+  @ViewChild('host', { static: true }) hostEl!: ElementRef<HTMLDivElement>;
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  private A: any = null;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  private aladin: any = null;
+  private ready = false;
+
+  constructor(private zone: NgZone) {}
+
+  ngAfterViewInit(): void {
+    this.zone.runOutsideAngular(() => {
+      import('aladin-lite').then((mod) => {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        this.A = (mod as any).default ?? mod;
+        const fovDeg = this.viewFov();
+        this.aladin = this.A.aladin(this.hostEl.nativeElement, {
+          survey: 'P/DSS2/color',
+          fov: fovDeg,
+          target: `${this.ra} ${this.dec}`,
+          showReticle: true,
+          showZoomControl: true,
+          showFullscreenControl: false,
+          showLayersControl: true,
+          showGotoControl: false,
+          showShareControl: false,
+        });
+        this.ready = true;
+        this.drawOverlay();
+      });
+    });
+  }
+
+  ngOnChanges(): void {
+    if (!this.ready || !this.aladin) return;
+    this.zone.runOutsideAngular(() => {
+      this.aladin.gotoRaDec(this.ra, this.dec);
+      this.aladin.setFov(this.viewFov());
+      this.drawOverlay();
+    });
+  }
+
+  ngOnDestroy(): void {
+    this.aladin = null;
+    this.A = null;
+    this.ready = false;
+  }
+
+  private viewFov(): number {
+    return this.fovMultiplier * Math.max(this.fovWidthDeg || 1, this.fovHeightDeg || 1);
+  }
+
+  private drawOverlay(): void {
+    if (!this.aladin || !this.A) return;
+    try {
+      this.aladin.removeLayers();
+      const overlay = this.A.graphicOverlay({ color: '#fff', lineWidth: 2 });
+      this.aladin.addLayer(overlay);
+      const corners = fovCorners(
+        this.ra, this.dec,
+        this.fovWidthDeg, this.fovHeightDeg,
+        this.rotation ?? 0
+      );
+      overlay.add(this.A.polygon(corners));
+    } catch {
+      // overlay API may differ across Aladin Lite beta versions; fail silently
+    }
+  }
+}

--- a/src/app/components/sky-view/sky-view.component.ts
+++ b/src/app/components/sky-view/sky-view.component.ts
@@ -9,29 +9,7 @@ import {
   NgZone,
   inject
 } from '@angular/core';
-
-/** FOV rectangle corners in WCS space for an Aladin polygon overlay. */
-function fovCorners(
-  ra: number, dec: number,
-  wDeg: number, hDeg: number,
-  rotDeg: number
-): [number, number][] {
-  const rotRad = (rotDeg * Math.PI) / 180;
-  const hw = wDeg / 2;
-  const hh = hDeg / 2;
-  const cosD = Math.cos((dec * Math.PI) / 180);
-  return (
-    [[-hw, -hh], [hw, -hh], [hw, hh], [-hw, hh]] as [number, number][]
-  ).map(([dx, dy]) => [
-    ra + (dx * Math.cos(rotRad) + dy * Math.sin(rotRad)) / cosD,
-    dec + (-dx * Math.sin(rotRad) + dy * Math.cos(rotRad))
-  ]);
-}
-
-/** Compute FOV dimension in degrees from sensor geometry. */
-export function computeFovDeg(pixels: number, pixelMicron: number, focalMm: number): number {
-  return 2 * Math.atan((pixels * pixelMicron / 1000) / (2 * focalMm)) * (180 / Math.PI);
-}
+import { fovCorners, raHoursToDegrees } from '../../utils/fov';
 
 @Component({
   selector: 'app-sky-view',
@@ -43,7 +21,9 @@ export function computeFovDeg(pixels: number, pixelMicron: number, focalMm: numb
   `]
 })
 export class SkyViewComponent implements AfterViewInit, OnChanges, OnDestroy {
+  /** Right ascension in hours (API convention). */
   @Input() ra!: number;
+  /** Declination in degrees. */
   @Input() dec!: number;
   @Input() fovWidthDeg!: number;
   @Input() fovHeightDeg!: number;
@@ -59,27 +39,34 @@ export class SkyViewComponent implements AfterViewInit, OnChanges, OnDestroy {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   private aladin: any = null;
   private ready = false;
+  private destroyed = false;
   private zone = inject(NgZone);
 
   ngAfterViewInit(): void {
     this.zone.runOutsideAngular(() => {
       import('aladin-lite').then((mod) => {
+        if (this.destroyed) return;
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         this.A = (mod as any).default ?? mod;
-        const fovDeg = this.viewFov();
-        this.aladin = this.A.aladin(this.hostEl.nativeElement, {
-          survey: 'P/DSS2/color',
-          fov: fovDeg,
-          target: `${this.ra} ${this.dec}`,
-          showReticle: true,
-          showZoomControl: true,
-          showFullscreenControl: false,
-          showLayersControl: true,
-          showGotoControl: false,
-          showShareControl: false,
+        // A.init resolves once the WASM backend is ready (aladin-lite v3 requirement)
+        Promise.resolve(this.A.init).then(() => {
+          if (this.destroyed || !this.hostEl?.nativeElement) return;
+          const raDeg = raHoursToDegrees(this.ra);
+          const fovDeg = this.viewFov();
+          this.aladin = this.A.aladin(this.hostEl.nativeElement, {
+            survey: 'P/DSS2/color',
+            fov: fovDeg,
+            target: `${raDeg} ${this.dec}`,
+            showReticle: true,
+            showZoomControl: true,
+            showFullscreenControl: false,
+            showLayersControl: true,
+            showGotoControl: false,
+            showShareControl: false,
+          });
+          this.ready = true;
+          this.drawOverlay();
         });
-        this.ready = true;
-        this.drawOverlay();
       });
     });
   }
@@ -87,14 +74,15 @@ export class SkyViewComponent implements AfterViewInit, OnChanges, OnDestroy {
   ngOnChanges(): void {
     if (!this.ready || !this.aladin) return;
     this.zone.runOutsideAngular(() => {
-      this.aladin.gotoRaDec(this.ra, this.dec);
+      this.aladin.gotoRaDec(raHoursToDegrees(this.ra), this.dec);
       this.aladin.setFov(this.viewFov());
       this.drawOverlay();
     });
   }
 
   ngOnDestroy(): void {
-    this.aladin = null;
+    this.destroyed = true;
+    this.destroyAladin();
     this.A = null;
     this.ready = false;
   }
@@ -106,17 +94,31 @@ export class SkyViewComponent implements AfterViewInit, OnChanges, OnDestroy {
   private drawOverlay(): void {
     if (!this.aladin || !this.A) return;
     try {
-      this.aladin.removeLayers();
+      this.aladin.removeOverlays();
       const overlay = this.A.graphicOverlay({ color: '#fff', lineWidth: 2 });
-      this.aladin.addLayer(overlay);
+      this.aladin.addOverlay(overlay);
       const corners = fovCorners(
-        this.ra, this.dec,
-        this.fovWidthDeg, this.fovHeightDeg,
+        raHoursToDegrees(this.ra),
+        this.dec,
+        this.fovWidthDeg,
+        this.fovHeightDeg,
         this.rotation ?? 0
       );
       overlay.add(this.A.polygon(corners));
     } catch {
       // overlay API may differ across Aladin Lite beta versions; fail silently
     }
+  }
+
+  private destroyAladin(): void {
+    try {
+      this.aladin?.remove?.();
+    } catch {
+      /* ignore */
+    }
+    if (this.hostEl?.nativeElement) {
+      this.hostEl.nativeElement.innerHTML = '';
+    }
+    this.aladin = null;
   }
 }

--- a/src/app/components/task-view/task-view.component.spec.ts
+++ b/src/app/components/task-view/task-view.component.spec.ts
@@ -60,7 +60,8 @@ describe('TaskViewComponent', () => {
     alt: null as number | null,
     sensor: null,
     active: true,
-    filters: [{ filter_id: 1, short_name: 'L', full_name: 'Lum', active: true }]
+    filters: [{ filter_id: 1, short_name: 'L', full_name: 'Lum', active: true }],
+    default_rotation: null
   };
 
   beforeEach(async () => {

--- a/src/app/components/telescope-detail/telescope-detail.component.css
+++ b/src/app/components/telescope-detail/telescope-detail.component.css
@@ -16,6 +16,26 @@
   margin: 0;
   max-width: none;
 }
+.param-group {
+  margin: 0.65rem 0;
+  padding: 0.65rem 0.85rem;
+  border: 1px solid rgba(0, 0, 0, 0.1);
+  border-radius: 10px;
+  background: rgba(0, 0, 0, 0.02);
+}
+.param-group p {
+  margin: 0.25rem 0;
+}
+.param-group p:first-child {
+  margin-top: 0;
+}
+.param-group p:last-child {
+  margin-bottom: 0;
+}
+.param-sep {
+  margin: 0 0.35rem;
+  color: rgba(0, 0, 0, 0.35);
+}
 .scope-map-card {
   margin: 0;
 }

--- a/src/app/components/telescope-detail/telescope-detail.component.html
+++ b/src/app/components/telescope-detail/telescope-detail.component.html
@@ -27,7 +27,9 @@
           <mat-card-title>{{ telescope.name }}</mat-card-title>
         </mat-card-header>
         <mat-card-content>
-          <p><strong>Description:</strong> {{ telescope.descr || '—' }}</p>
+          <div class="param-group">
+            <p><strong>Description:</strong> {{ telescope.descr || '—' }}</p>
+          </div>
 
           <div class="param-group">
             <p>
@@ -66,9 +68,9 @@
               <span class="param-sep">·</span>
               <strong>Scale:</strong> {{ formatAngularResolution() ?? '—' }}
             </p>
+            <p><strong>Default rotation:</strong> {{ formatDefaultRotation(telescope.default_rotation) }}</p>
           </div>
 
-          <p><strong>Default rotation:</strong> {{ telescope.default_rotation !== null ? (telescope.default_rotation + '°') : '—' }}</p>
           <p><strong>Active:</strong> {{ telescope.active ? 'Yes' : 'No' }}</p>
         </mat-card-content>
       </mat-card>

--- a/src/app/components/telescope-detail/telescope-detail.component.html
+++ b/src/app/components/telescope-detail/telescope-detail.component.html
@@ -33,6 +33,7 @@
           <p><strong>Min Declination:</strong> {{ telescope.min_dec }}° <strong>Max Declination:</strong> {{ telescope.max_dec }}°</p>
           <p><strong>Latitude:</strong> {{ formatLatitude(telescope.lat) }} <strong>Longitude:</strong> {{ formatLongitude(telescope.lon) }} <strong>Altitude:</strong> {{ telescope.alt ?? '—' }} m</p>
           <p><strong>Sensor:</strong> {{ telescope.sensor?.name ?? '—' }}</p>
+          <p><strong>Default rotation:</strong> {{ telescope.default_rotation != null ? (telescope.default_rotation + '°') : '—' }}</p>
           <p><strong>Active:</strong> {{ telescope.active ? 'Yes' : 'No' }}</p>
         </mat-card-content>
       </mat-card>

--- a/src/app/components/telescope-detail/telescope-detail.component.html
+++ b/src/app/components/telescope-detail/telescope-detail.component.html
@@ -28,12 +28,47 @@
         </mat-card-header>
         <mat-card-content>
           <p><strong>Description:</strong> {{ telescope.descr || '—' }}</p>
-          <p><strong>Focal length (mm):</strong> {{ telescope.focal ?? '—' }}</p>
-          <p><strong>Aperture:</strong> {{ formatApertureWithInches(telescope.aperture) }}</p>
-          <p><strong>Min Declination:</strong> {{ telescope.min_dec }}° <strong>Max Declination:</strong> {{ telescope.max_dec }}°</p>
-          <p><strong>Latitude:</strong> {{ formatLatitude(telescope.lat) }} <strong>Longitude:</strong> {{ formatLongitude(telescope.lon) }} <strong>Altitude:</strong> {{ telescope.alt ?? '—' }} m</p>
-          <p><strong>Sensor:</strong> {{ telescope.sensor?.name ?? '—' }}</p>
-          <p><strong>Default rotation:</strong> {{ telescope.default_rotation != null ? (telescope.default_rotation + '°') : '—' }}</p>
+
+          <div class="param-group">
+            <p>
+              <strong>Focal length:</strong> {{ telescope.focal !== null ? telescope.focal + ' mm' : '—' }}
+              <span class="param-sep">·</span>
+              <strong>Aperture:</strong> {{ formatApertureWithInches(telescope.aperture) }}
+              <span class="param-sep">·</span>
+              <strong>F-number:</strong> {{ formatFNumber() ?? '—' }}
+            </p>
+          </div>
+
+          <div class="param-group">
+            <p>
+              <strong>Min Declination:</strong> {{ telescope.min_dec }}°
+              <span class="param-sep">·</span>
+              <strong>Max Declination:</strong> {{ telescope.max_dec }}°
+            </p>
+            <p>
+              <strong>Latitude:</strong> {{ formatLatitude(telescope.lat) }}
+              <span class="param-sep">·</span>
+              <strong>Longitude:</strong> {{ formatLongitude(telescope.lon) }}
+              <span class="param-sep">·</span>
+              <strong>Altitude:</strong> {{ telescope.alt ?? '—' }} m
+            </p>
+          </div>
+
+          <div class="param-group">
+            <p><strong>Sensor:</strong> {{ telescope.sensor?.name ?? '—' }}</p>
+            <p>
+              <strong>Resolution:</strong> {{ formatSensorResolution() ?? '—' }}
+              <span class="param-sep">·</span>
+              <strong>Pixel size:</strong> {{ formatPixelSize() ?? '—' }}
+            </p>
+            <p>
+              <strong>FOV:</strong> {{ formatFov() ?? '—' }}
+              <span class="param-sep">·</span>
+              <strong>Scale:</strong> {{ formatAngularResolution() ?? '—' }}
+            </p>
+          </div>
+
+          <p><strong>Default rotation:</strong> {{ telescope.default_rotation !== null ? (telescope.default_rotation + '°') : '—' }}</p>
           <p><strong>Active:</strong> {{ telescope.active ? 'Yes' : 'No' }}</p>
         </mat-card-content>
       </mat-card>

--- a/src/app/components/telescope-detail/telescope-detail.component.ts
+++ b/src/app/components/telescope-detail/telescope-detail.component.ts
@@ -13,7 +13,7 @@ import { AddFilterToScopeDialogComponent } from '../add-filter-to-scope-dialog/a
 import { Filter } from '../../models/filter';
 import { TelescopeFormDialogComponent } from '../telescope-form-dialog/telescope-form-dialog.component';
 import { ProjectsListComponent } from '../projects-list/projects-list.component';
-import { computeFovDeg } from '../sky-view/sky-view.component';
+import { computeFovDeg } from '../../utils/fov';
 import * as L from 'leaflet';
 
 @Component({
@@ -185,6 +185,14 @@ export class TelescopeDetailComponent implements OnInit, AfterViewInit, OnDestro
     const w = computeFovDeg(s.resx, s.pixel_x, t.focal);
     const h = computeFovDeg(s.resy, s.pixel_y, t.focal);
     return `${w.toFixed(2)}° × ${h.toFixed(2)}°`;
+  }
+
+  /** Camera default rotation, or em dash when unset. */
+  formatDefaultRotation(value: number | null | undefined): string {
+    if (value == null) {
+      return '—';
+    }
+    return `${value}°`;
   }
 
   /** Angular resolution (plate scale) in arcsec/pixel. */

--- a/src/app/components/telescope-detail/telescope-detail.component.ts
+++ b/src/app/components/telescope-detail/telescope-detail.component.ts
@@ -13,6 +13,7 @@ import { AddFilterToScopeDialogComponent } from '../add-filter-to-scope-dialog/a
 import { Filter } from '../../models/filter';
 import { TelescopeFormDialogComponent } from '../telescope-form-dialog/telescope-form-dialog.component';
 import { ProjectsListComponent } from '../projects-list/projects-list.component';
+import { computeFovDeg } from '../sky-view/sky-view.component';
 import * as L from 'leaflet';
 
 @Component({
@@ -141,6 +142,64 @@ export class TelescopeDetailComponent implements OnInit, AfterViewInit, OnDestro
     const roundedOneDecimal = Math.round(inches * 10) / 10;
     const inchText = Number.isInteger(roundedOneDecimal) ? `${roundedOneDecimal.toFixed(0)}` : `${roundedOneDecimal.toFixed(1)}`;
     return `${aperture}mm (${inchText}")`;
+  }
+
+  /** Focal ratio as F/N with one decimal place, or null when inputs are missing. */
+  formatFNumber(): string | null {
+    const focal = this.telescope?.focal;
+    const aperture = this.telescope?.aperture;
+    if (focal == null || aperture == null || aperture <= 0) {
+      return null;
+    }
+    return `F/${(focal / aperture).toFixed(1)}`;
+  }
+
+  /** Sensor resolution as width × height in pixels. */
+  formatSensorResolution(): string | null {
+    const s = this.telescope?.sensor;
+    if (!s?.resx || !s?.resy) {
+      return null;
+    }
+    return `${s.resx} × ${s.resy} px`;
+  }
+
+  /** Pixel size in μm; one value when square, otherwise X × Y. */
+  formatPixelSize(): string | null {
+    const s = this.telescope?.sensor;
+    if (!s?.pixel_x || !s?.pixel_y) {
+      return null;
+    }
+    if (Math.abs(s.pixel_x - s.pixel_y) < 0.005) {
+      return `${s.pixel_x} μm`;
+    }
+    return `${s.pixel_x} × ${s.pixel_y} μm`;
+  }
+
+  /** FOV width × height in degrees from sensor + focal length. */
+  formatFov(): string | null {
+    const t = this.telescope;
+    const s = t?.sensor;
+    if (!t?.focal || !s?.resx || !s?.resy || !s?.pixel_x || !s?.pixel_y) {
+      return null;
+    }
+    const w = computeFovDeg(s.resx, s.pixel_x, t.focal);
+    const h = computeFovDeg(s.resy, s.pixel_y, t.focal);
+    return `${w.toFixed(2)}° × ${h.toFixed(2)}°`;
+  }
+
+  /** Angular resolution (plate scale) in arcsec/pixel. */
+  formatAngularResolution(): string | null {
+    const t = this.telescope;
+    const s = t?.sensor;
+    if (!t?.focal || !s?.pixel_x || !s?.pixel_y || t.focal <= 0) {
+      return null;
+    }
+    const scaleX = (206.265 * s.pixel_x) / t.focal;
+    const scaleY = (206.265 * s.pixel_y) / t.focal;
+    if (Math.abs(scaleX - scaleY) < 0.005) {
+      return `${scaleX.toFixed(2)}″/px`;
+    }
+    return `${scaleX.toFixed(2)}″ × ${scaleY.toFixed(2)}″/px`;
   }
 
   hasMapCoordinates(): boolean {

--- a/src/app/components/telescope-form-dialog/telescope-form-dialog.component.html
+++ b/src/app/components/telescope-form-dialog/telescope-form-dialog.component.html
@@ -94,6 +94,14 @@
         }
       </mat-select>
     </mat-form-field>
+    <mat-form-field appearance="outline" class="full-width" subscriptSizing="dynamic">
+      <mat-label>Default rotation (°)</mat-label>
+      <input matInput formControlName="default_rotation" type="number" min="0" max="359.99" step="0.01" placeholder="e.g. 90.5" autocomplete="off">
+      <mat-hint>Degrees East of North (0–359.99). Leave empty to clear.</mat-hint>
+      @if (form.get('default_rotation')?.touched && form.get('default_rotation')?.hasError('rotationRange')) {
+        <mat-error>Must be between 0 and 359.99</mat-error>
+      }
+    </mat-form-field>
     <mat-checkbox formControlName="active">Active</mat-checkbox>
   </form>
 </mat-dialog-content>

--- a/src/app/components/telescope-form-dialog/telescope-form-dialog.component.ts
+++ b/src/app/components/telescope-form-dialog/telescope-form-dialog.component.ts
@@ -37,6 +37,19 @@ function optionalNonNegativeNumber(c: AbstractControl): ValidationErrors | null 
   return null;
 }
 
+/** Optional camera rotation in degrees East of North (0–359.99). Empty clears. */
+function optionalDefaultRotation(c: AbstractControl): ValidationErrors | null {
+  const raw = String(c.value ?? '').trim();
+  if (!raw) {
+    return null;
+  }
+  const n = Number(raw);
+  if (!Number.isFinite(n) || n < 0 || n > 359.99) {
+    return { rotationRange: true };
+  }
+  return null;
+}
+
 function optionalDecLimit(c: AbstractControl): ValidationErrors | null {
   const raw = String(c.value ?? '').trim();
   if (!raw) {
@@ -126,6 +139,7 @@ export class TelescopeFormDialogComponent {
         lat: [numStr(t?.lat), latFieldValidator],
         alt: [numStr(t?.alt), optionalNonNegativeNumber],
         sensor_id: [t?.sensor?.sensor_id ?? null],
+        default_rotation: [numStr(t?.default_rotation), optionalDefaultRotation],
         active: [t?.active ?? true]
       },
       { validators: [minMaxDecOrderValidator] }
@@ -182,6 +196,11 @@ export class TelescopeFormDialogComponent {
       this.snackBar.open('Invalid longitude or latitude', 'Close', { duration: 4000 });
       return;
     }
+    const rotRaw = String(v.default_rotation ?? '').trim();
+    const defaultRotation = rotRaw === '' ? null : Number(rotRaw);
+    const default_rotation =
+      defaultRotation != null && Number.isFinite(defaultRotation) ? defaultRotation : null;
+
     if (this.mode === 'add') {
       const body: ScopeCreate = {
         name: v.name,
@@ -194,7 +213,8 @@ export class TelescopeFormDialogComponent {
         lat,
         alt: numOpt(v.alt),
         sensor_id: v.sensor_id != null && v.sensor_id !== '' ? Number(v.sensor_id) : undefined,
-        active: v.active
+        active: v.active,
+        default_rotation
       };
       this.telescopeService.createTelescope(body).subscribe({
         next: () => {
@@ -219,7 +239,8 @@ export class TelescopeFormDialogComponent {
         lat,
         alt: numOpt(v.alt),
         sensor_id: v.sensor_id != null && v.sensor_id !== '' ? Number(v.sensor_id) : 0,
-        active: v.active
+        active: v.active,
+        default_rotation
       };
       const scopeId = this.data.telescope!.scope_id;
       this.telescopeService.updateTelescope(scopeId, body).subscribe({

--- a/src/app/components/telescope-list/telescope-list.component.spec.ts
+++ b/src/app/components/telescope-list/telescope-list.component.spec.ts
@@ -37,7 +37,8 @@ describe('TelescopeListComponent', () => {
         width: 20,
         height: 20
       },
-      active: true
+      active: true,
+      default_rotation: null
     },
     {
       scope_id: 2,
@@ -51,7 +52,8 @@ describe('TelescopeListComponent', () => {
       lat: null,
       alt: null,
       sensor: null,
-      active: false
+      active: false,
+      default_rotation: null
     }
   ];
 

--- a/src/app/models/project.ts
+++ b/src/app/models/project.ts
@@ -33,6 +33,18 @@ export interface Project {
   end_date?: string | null;
   /** Space-separated publication URLs (social posts, galleries). */
   publications?: string | null;
+  /** Camera position angle, degrees East of North. null = not set. */
+  rotation?: number | null;
+  /** Focal length (mm) stored at project creation; copied from telescope. */
+  focal?: number | null;
+  /** Sensor width (pixels) stored at project creation; copied from sensor. */
+  resx?: number | null;
+  /** Sensor height (pixels) stored at project creation; copied from sensor. */
+  resy?: number | null;
+  /** Pixel pitch X (µm) stored at project creation; copied from sensor. */
+  pixel_x?: number | null;
+  /** Pixel pitch Y (µm) stored at project creation; copied from sensor. */
+  pixel_y?: number | null;
   subframes?: ProjectSubframe[];
   user_ids?: number[];
 }
@@ -48,6 +60,12 @@ export interface ProjectCreate {
   start_date?: string | null;
   end_date?: string | null;
   publications?: string | null;
+  rotation?: number | null;
+  focal?: number | null;
+  resx?: number | null;
+  resy?: number | null;
+  pixel_x?: number | null;
+  pixel_y?: number | null;
 }
 
 export interface ProjectUpdate {
@@ -61,6 +79,12 @@ export interface ProjectUpdate {
   start_date?: string | null;
   end_date?: string | null;
   publications?: string | null;
+  rotation?: number | null;
+  focal?: number | null;
+  resx?: number | null;
+  resy?: number | null;
+  pixel_x?: number | null;
+  pixel_y?: number | null;
 }
 
 export interface ProjectSubframeCreate {

--- a/src/app/services/telescope.service.spec.ts
+++ b/src/app/services/telescope.service.spec.ts
@@ -58,7 +58,8 @@ describe('TelescopeService', () => {
             height: 20
           },
           filters: [],
-          active: true
+          active: true,
+          default_rotation: null
         }
       ]
     };
@@ -99,7 +100,8 @@ describe('TelescopeService', () => {
         alt: null,
         sensor: null,
         filters: [],
-        active: false
+        active: false,
+        default_rotation: null
       }
     });
   });

--- a/src/app/services/telescope.service.ts
+++ b/src/app/services/telescope.service.ts
@@ -30,6 +30,8 @@ export interface Telescope {
   } | null;
   filters?: Filter[];
   active: boolean;
+  /** Degrees East of North; null when unset. See scopes API in hevelius-backend. */
+  default_rotation: number | null;
 }
 
 export interface TelescopesListParams {
@@ -136,6 +138,7 @@ export interface ScopeCreate {
   alt?: number;
   sensor_id?: number;
   active?: boolean;
+  default_rotation?: number | null;
 }
 
 export interface ScopeUpdate {
@@ -150,4 +153,6 @@ export interface ScopeUpdate {
   alt?: number;
   sensor_id?: number;
   active?: boolean;
+  /** Send null to clear. */
+  default_rotation?: number | null;
 }

--- a/src/app/utils/fov.spec.ts
+++ b/src/app/utils/fov.spec.ts
@@ -1,0 +1,41 @@
+import { computeFovDeg, raHoursToDegrees } from './fov';
+
+describe('computeFovDeg', () => {
+  it('computes correct FOV for a known setup', () => {
+    // QSI 583ws: 3326 px × 5.4 µm, focal 2541 mm
+    // = 2 * atan((3326 * 5.4/1000) / (2 * 2541)) * (180/π) ≈ 0.405°
+    const fov = computeFovDeg(3326, 5.4, 2541);
+    expect(fov).toBeCloseTo(0.405, 2);
+  });
+
+  it('is symmetric: swapping pixels and focal scales proportionally', () => {
+    const a = computeFovDeg(1000, 5, 500);
+    const b = computeFovDeg(2000, 5, 1000);
+    expect(a).toBeCloseTo(b, 6);
+  });
+
+  it('returns a positive value for valid inputs', () => {
+    expect(computeFovDeg(1000, 5, 500)).toBeGreaterThan(0);
+  });
+
+  it('increases with sensor size', () => {
+    const small = computeFovDeg(1000, 5, 1000);
+    const large = computeFovDeg(2000, 5, 1000);
+    expect(large).toBeGreaterThan(small);
+  });
+
+  it('decreases with longer focal length', () => {
+    const wide = computeFovDeg(1000, 5, 500);
+    const narrow = computeFovDeg(1000, 5, 2000);
+    expect(narrow).toBeLessThan(wide);
+  });
+});
+
+describe('raHoursToDegrees', () => {
+  it('converts hours to degrees', () => {
+    expect(raHoursToDegrees(0)).toBe(0);
+    expect(raHoursToDegrees(1)).toBe(15);
+    expect(raHoursToDegrees(12)).toBe(180);
+    expect(raHoursToDegrees(24)).toBe(360);
+  });
+});

--- a/src/app/utils/fov.ts
+++ b/src/app/utils/fov.ts
@@ -1,0 +1,38 @@
+/**
+ * Field-of-view helpers for sensor geometry and Aladin polygon overlays.
+ */
+
+/** FOV rectangle corners in WCS (degrees) for an Aladin polygon overlay. */
+export function fovCorners(
+  raDeg: number,
+  decDeg: number,
+  wDeg: number,
+  hDeg: number,
+  rotDeg: number
+): [number, number][] {
+  const rotRad = (rotDeg * Math.PI) / 180;
+  const hw = wDeg / 2;
+  const hh = hDeg / 2;
+  const cosD = Math.cos((decDeg * Math.PI) / 180);
+  return (
+    [
+      [-hw, -hh],
+      [hw, -hh],
+      [hw, hh],
+      [-hw, hh]
+    ] as [number, number][]
+  ).map(([dx, dy]) => [
+    raDeg + (dx * Math.cos(rotRad) + dy * Math.sin(rotRad)) / cosD,
+    decDeg + (-dx * Math.sin(rotRad) + dy * Math.cos(rotRad))
+  ]);
+}
+
+/** Compute FOV dimension in degrees from sensor geometry. */
+export function computeFovDeg(pixels: number, pixelMicron: number, focalMm: number): number {
+  return 2 * Math.atan((pixels * pixelMicron / 1000) / (2 * focalMm)) * (180 / Math.PI);
+}
+
+/** Convert RA from hours (API) to degrees (Aladin Lite). */
+export function raHoursToDegrees(raHours: number): number {
+  return raHours * 15;
+}


### PR DESCRIPTION
## Summary
This PR adds a new sky map component for visualizing all projects across the sky, and introduces optical parameter tracking (focal length, sensor dimensions, pixel pitch) to projects. These parameters enable precise field-of-view calculations and visualization overlays in both the new sky map and project detail views.

## Key Changes

- **New SkyMapComponent**: Full-sky visualization using Aladin Lite showing all active projects as FOV polygons or point markers, with per-scope filtering via chips
- **New SkyViewComponent**: Reusable sky view widget for displaying a zoomed view of a specific project's field of view with rotation support
- **Optical Parameters**: Extended Project model with `focal`, `resx`, `resy`, `pixel_x`, `pixel_y`, and `rotation` fields
- **FOV Calculation**: Added `computeFovDeg()` utility function to derive field-of-view dimensions from sensor geometry (pixels, pixel pitch, focal length)
- **Project Form Enhancement**: 
  - Added optical parameters section to project creation dialog
  - Auto-populate sensor specs from selected telescope via TelescopeService
  - Display computed FOV as a chip when all parameters are available
- **Project Detail Enhancement**: Conditionally render SkyViewComponent when FOV data is complete
- **Navigation**: Added "Sky Map" menu item to main layout
- **Routing**: Added `/sky-map` route
- **Dependencies**: Added `aladin-lite@^3.9.0-beta` for sky visualization

## Implementation Details

- Aladin Lite integration runs outside Angular's zone for performance
- FOV corners are computed in WCS space accounting for declination and camera rotation
- Scope colors cycle through a predefined palette for visual distinction
- Graceful fallback: projects without optical parameters show as point markers instead of FOV polygons
- Comprehensive test coverage for new components and utility functions

https://claude.ai/code/session_01Mn5wvy2To8d95XVLTBcRXE