### PR TITLE
Add asteroids list and detail pages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 0.6.0 (unreleased)
 
+- Added **Asteroids** page (`/asteroids`) listing minor planets from the MPC
+  catalogue, with paging, sorting, and filtering (designation, number,
+  numbered/provisional, absolute magnitude range); click a row to view an
+  asteroid's full orbital element details (`/asteroids/:id`).
 - Detailed telescope view extended: many new parameters shown (F number,
   default rotation, camera details, FOV etc).
 - Default camera rotation for a telescope is now supported.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 0.6.0 (unreleased)
 
+- Added tags for asteroids (families such as amor/NEO/PHA, fast rotators,
+  visited by spacecraft, etc.): filter the Asteroids list by one or more
+  tags (match any or all), see tags as colored chips in the list, and
+  add/remove tags for a single asteroid from its detail page — typing a
+  name that doesn't exist yet creates the tag and attaches it in one step.
 - Added **Asteroids** page (`/asteroids`) listing minor planets from the MPC
   catalogue, with paging, sorting, and filtering (designation, number,
   numbered/provisional, absolute magnitude range); click a row to view an

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 0.6.0 (unreleased)
 
+- Asteroid detail page reorganized into three widgets: grouped orbital
+  elements (identification / orbital elements / photometric), tags, and a
+  new **Visibility** widget — pick an active telescope (its location drives
+  the calculation) and a night (defaults to tonight, overridable via a date
+  picker) to see an altitude/time chart for the night, the peak altitude and
+  time, an estimated apparent magnitude when the asteroid's absolute
+  magnitude is known, or a clear "not visible" message when it never rises
+  above the horizon. The underlying orbital-mechanics computation runs on
+  the backend so the same logic can be reused by a future CLI command.
 - Added tags for asteroids (families such as amor/NEO/PHA, fast rotators,
   visited by spacecraft, etc.): filter the Asteroids list by one or more
   tags (match any or all), see tags as colored chips in the list, and

--- a/src/app/app-routing.module.ts
+++ b/src/app/app-routing.module.ts
@@ -11,6 +11,8 @@ import { ProjectDetailComponent } from './components/project-detail/project-deta
 import { FiltersListComponent } from './components/filters-list/filters-list.component';
 import { ObjectsComponent } from './components/objects/objects.component';
 import { CatalogsListComponent } from './components/catalogs-list/catalogs-list.component';
+import { AsteroidsListComponent } from './components/asteroids-list/asteroids-list.component';
+import { AsteroidDetailComponent } from './components/asteroid-detail/asteroid-detail.component';
 import { UserComponent } from './components/user/user.component';
 import { SkyMapComponent } from './components/sky-map/sky-map.component';
 import { AuthGuard } from './guards/auth.guard';
@@ -32,6 +34,8 @@ export const routes: Routes = [
       { path: 'projects/:id', component: ProjectDetailComponent },
       { path: 'objects', component: ObjectsComponent },
       { path: 'catalogs', component: CatalogsListComponent },
+      { path: 'asteroids', component: AsteroidsListComponent },
+      { path: 'asteroids/:id', component: AsteroidDetailComponent },
       { path: 'user', component: UserComponent },
       { path: 'sky-map', component: SkyMapComponent },
       { path: '', redirectTo: 'projects', pathMatch: 'full' }

--- a/src/app/components/asteroid-detail/asteroid-detail.component.css
+++ b/src/app/components/asteroid-detail/asteroid-detail.component.css
@@ -1,0 +1,32 @@
+.container {
+  padding: 20px;
+}
+
+.asteroid-actions {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+}
+
+.asteroid-card {
+  margin: 1rem 0;
+  max-width: 640px;
+}
+
+.number-badge {
+  margin-left: 0.5rem;
+  font-size: 0.9rem;
+  color: #616161;
+  font-weight: 400;
+}
+
+.fields-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(260px, 1fr));
+  gap: 0.25rem 1.5rem;
+}
+
+.fields-grid p {
+  margin: 0.4rem 0;
+}

--- a/src/app/components/asteroid-detail/asteroid-detail.component.css
+++ b/src/app/components/asteroid-detail/asteroid-detail.component.css
@@ -31,6 +31,23 @@
   margin: 0.4rem 0;
 }
 
+.element-group {
+  margin-bottom: 1.25rem;
+}
+
+.element-group:last-child {
+  margin-bottom: 0;
+}
+
+.group-heading {
+  margin: 0 0 0.5rem;
+  font-size: 0.85rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: #616161;
+}
+
 .tags-card {
   margin: 1rem 0;
   max-width: 640px;
@@ -53,4 +70,91 @@
 
 .add-tag-field {
   flex: 1 1 auto;
+}
+
+.visibility-card {
+  margin: 1rem 0;
+  max-width: 640px;
+}
+
+.visibility-controls {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+  margin-bottom: 1rem;
+}
+
+.scope-field {
+  flex: 1 1 220px;
+}
+
+.date-field {
+  flex: 1 1 160px;
+}
+
+.visibility-hint {
+  color: #757575;
+  font-size: 0.9rem;
+}
+
+.visibility-loading {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  color: #616161;
+}
+
+.visibility-error {
+  color: #c62828;
+  font-size: 0.9rem;
+}
+
+.not-visible {
+  color: #757575;
+}
+
+.visibility-summary {
+  margin-bottom: 0.75rem;
+}
+
+.muted {
+  color: #757575;
+  font-size: 0.85rem;
+}
+
+.elevation-chart {
+  width: 100%;
+  height: 160px;
+  background: #fafafa;
+  border: 1px solid #e0e0e0;
+  border-radius: 4px;
+}
+
+.horizon-line {
+  stroke: #bdbdbd;
+  stroke-width: 1;
+  stroke-dasharray: 4 3;
+}
+
+.elevation-line {
+  fill: none;
+  stroke: #1976d2;
+  stroke-width: 2;
+}
+
+.max-point {
+  fill: #d32f2f;
+}
+
+.chart-axis-labels {
+  display: flex;
+  justify-content: space-between;
+  margin-top: 0.25rem;
+  font-size: 0.75rem;
+  color: #757575;
+}
+
+.axis-mid-label {
+  flex: 1;
+  text-align: center;
 }

--- a/src/app/components/asteroid-detail/asteroid-detail.component.css
+++ b/src/app/components/asteroid-detail/asteroid-detail.component.css
@@ -30,3 +30,27 @@
 .fields-grid p {
   margin: 0.4rem 0;
 }
+
+.tags-card {
+  margin: 1rem 0;
+  max-width: 640px;
+}
+
+.tags-chip-set {
+  margin-bottom: 0.75rem;
+}
+
+.no-tags {
+  color: #757575;
+  font-size: 0.9rem;
+}
+
+.add-tag-form {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.5rem;
+}
+
+.add-tag-field {
+  flex: 1 1 auto;
+}

--- a/src/app/components/asteroid-detail/asteroid-detail.component.html
+++ b/src/app/components/asteroid-detail/asteroid-detail.component.html
@@ -1,0 +1,46 @@
+@if (notFound) {
+  <div class="container">
+    <p>Asteroid not found.</p>
+    <button mat-raised-button color="primary" (click)="backToList()">
+      <mat-icon>arrow_back</mat-icon>
+      Back to asteroids
+    </button>
+  </div>
+} @else if (!asteroid) {
+  <p>Loading…</p>
+} @else {
+  <div class="container">
+    <div class="asteroid-actions">
+      <button mat-raised-button color="primary" (click)="backToList()">
+        <mat-icon>arrow_back</mat-icon>
+        Back to asteroids
+      </button>
+    </div>
+
+    <mat-card class="asteroid-card">
+      <mat-card-header>
+        <mat-card-title>
+          {{ asteroid.designation }}
+          @if (asteroid.number !== null) { <span class="number-badge">#{{ asteroid.number }}</span> }
+        </mat-card-title>
+        @if (isProvisional()) {
+          <mat-card-subtitle>Unnumbered / provisional designation</mat-card-subtitle>
+        }
+      </mat-card-header>
+      <mat-card-content>
+        <div class="fields-grid">
+          <p><strong>Epoch:</strong> {{ asteroid.epoch }}</p>
+          <p><strong>Absolute magnitude (H):</strong> {{ asteroid.absolute_magnitude ?? '—' }}</p>
+          <p><strong>Slope parameter (G):</strong> {{ asteroid.slope_parameter ?? '—' }}</p>
+          <p><strong>Semi-major axis (a):</strong> {{ asteroid.semimajor_axis }} AU</p>
+          <p><strong>Eccentricity (e):</strong> {{ asteroid.eccentricity }}</p>
+          <p><strong>Inclination (i):</strong> {{ asteroid.inclination }}°</p>
+          <p><strong>Longitude of ascending node (Ω):</strong> {{ asteroid.ascending_node }}°</p>
+          <p><strong>Argument of perihelion (ω):</strong> {{ asteroid.perihelion_arg }}°</p>
+          <p><strong>Mean anomaly (M):</strong> {{ asteroid.mean_anomaly }}°</p>
+          <p><strong>Mean daily motion (n):</strong> {{ asteroid.mean_motion }}°/day</p>
+        </div>
+      </mat-card-content>
+    </mat-card>
+  </div>
+}

--- a/src/app/components/asteroid-detail/asteroid-detail.component.html
+++ b/src/app/components/asteroid-detail/asteroid-detail.component.html
@@ -28,17 +28,34 @@
         }
       </mat-card-header>
       <mat-card-content>
-        <div class="fields-grid">
-          <p><strong>Epoch:</strong> {{ asteroid.epoch }}</p>
-          <p><strong>Absolute magnitude (H):</strong> {{ asteroid.absolute_magnitude ?? '—' }}</p>
-          <p><strong>Slope parameter (G):</strong> {{ asteroid.slope_parameter ?? '—' }}</p>
-          <p><strong>Semi-major axis (a):</strong> {{ asteroid.semimajor_axis }} AU</p>
-          <p><strong>Eccentricity (e):</strong> {{ asteroid.eccentricity }}</p>
-          <p><strong>Inclination (i):</strong> {{ asteroid.inclination }}°</p>
-          <p><strong>Longitude of ascending node (Ω):</strong> {{ asteroid.ascending_node }}°</p>
-          <p><strong>Argument of perihelion (ω):</strong> {{ asteroid.perihelion_arg }}°</p>
-          <p><strong>Mean anomaly (M):</strong> {{ asteroid.mean_anomaly }}°</p>
-          <p><strong>Mean daily motion (n):</strong> {{ asteroid.mean_motion }}°/day</p>
+        <div class="element-group">
+          <h3 class="group-heading">Identification</h3>
+          <div class="fields-grid">
+            <p><strong>Designation:</strong> {{ asteroid.designation }}</p>
+            <p><strong>Number:</strong> {{ asteroid.number ?? '— (provisional)' }}</p>
+            <p><strong>Epoch:</strong> {{ asteroid.epoch }}</p>
+          </div>
+        </div>
+
+        <div class="element-group">
+          <h3 class="group-heading">Orbital elements</h3>
+          <div class="fields-grid">
+            <p><strong>Semi-major axis (a):</strong> {{ asteroid.semimajor_axis }} AU</p>
+            <p><strong>Eccentricity (e):</strong> {{ asteroid.eccentricity }}</p>
+            <p><strong>Inclination (i):</strong> {{ asteroid.inclination }}°</p>
+            <p><strong>Longitude of ascending node (Ω):</strong> {{ asteroid.ascending_node }}°</p>
+            <p><strong>Argument of perihelion (ω):</strong> {{ asteroid.perihelion_arg }}°</p>
+            <p><strong>Mean anomaly (M):</strong> {{ asteroid.mean_anomaly }}°</p>
+            <p><strong>Mean daily motion (n):</strong> {{ asteroid.mean_motion }}°/day</p>
+          </div>
+        </div>
+
+        <div class="element-group">
+          <h3 class="group-heading">Photometric</h3>
+          <div class="fields-grid">
+            <p><strong>Absolute magnitude (H):</strong> {{ asteroid.absolute_magnitude ?? '—' }}</p>
+            <p><strong>Slope parameter (G):</strong> {{ asteroid.slope_parameter ?? '—' }}</p>
+          </div>
         </div>
       </mat-card-content>
     </mat-card>
@@ -79,6 +96,75 @@
             Add
           </button>
         </div>
+      </mat-card-content>
+    </mat-card>
+
+    <mat-card class="visibility-card">
+      <mat-card-header>
+        <mat-card-title>Visibility</mat-card-title>
+      </mat-card-header>
+      <mat-card-content>
+        <div class="visibility-controls">
+          <mat-form-field subscriptSizing="dynamic" class="scope-field">
+            <mat-label>Telescope</mat-label>
+            <mat-select [formControl]="scopeControl" (selectionChange)="onScopeChange($event.value)">
+              @for (scope of activeTelescopes; track scope.scope_id) {
+                <mat-option [value]="scope.scope_id">{{ scope.name }}</mat-option>
+              } @empty {
+                <mat-option [value]="null" disabled>No active telescopes configured</mat-option>
+              }
+            </mat-select>
+          </mat-form-field>
+
+          <mat-form-field subscriptSizing="dynamic" class="date-field">
+            <mat-label>Night of</mat-label>
+            <input matInput [matDatepicker]="nightPicker" [formControl]="dateControl"
+                   (dateChange)="onDateChange($event.value)">
+            <mat-datepicker-toggle matIconSuffix [for]="nightPicker"></mat-datepicker-toggle>
+            <mat-datepicker #nightPicker></mat-datepicker>
+          </mat-form-field>
+        </div>
+
+        @if (scopeControl.value === null) {
+          <p class="visibility-hint">Pick a telescope to compute tonight's visibility.</p>
+        } @else if (visibilityLoading) {
+          <div class="visibility-loading">
+            <mat-spinner diameter="24"></mat-spinner>
+            <span>Computing…</span>
+          </div>
+        } @else if (visibilityError) {
+          <p class="visibility-error" role="alert">{{ visibilityError }}</p>
+        } @else if (visibility) {
+          @if (!visibility.visible) {
+            <p class="not-visible">
+              Not visible from {{ visibility.scope_name }} on the night of {{ dateControl.value | date: 'yyyy-MM-dd' }}
+              — it stays below the horizon all night (best altitude {{ visibility.max_altitude_deg }}°).
+            </p>
+          } @else {
+            <p class="visibility-summary">
+              Best altitude <strong>{{ visibility.max_altitude_deg }}°</strong>
+              at {{ formatTimeLabel(visibility.max_altitude_time) }} UTC from {{ visibility.scope_name }}.
+              @if (visibility.has_magnitude_estimate) {
+                Estimated magnitude <strong>{{ visibility.apparent_magnitude_at_max }}</strong>.
+              } @else {
+                <span class="muted">No absolute magnitude on file — apparent magnitude can't be estimated.</span>
+              }
+            </p>
+
+            <svg class="elevation-chart" [attr.viewBox]="chartViewBox" preserveAspectRatio="none">
+              <line class="horizon-line" x1="0" [attr.y1]="horizonY" [attr.x2]="600" [attr.y2]="horizonY"></line>
+              <polyline class="elevation-line" [attr.points]="chartPolylinePoints"></polyline>
+              @if (maxPoint; as p) {
+                <circle class="max-point" [attr.cx]="p.x" [attr.cy]="p.y" r="4"></circle>
+              }
+            </svg>
+            <div class="chart-axis-labels">
+              <span>{{ formatTimeLabel(visibility.night_start) }}</span>
+              <span class="axis-mid-label">altitude (horizon at 0°)</span>
+              <span>{{ formatTimeLabel(visibility.night_end) }}</span>
+            </div>
+          }
+        }
       </mat-card-content>
     </mat-card>
   </div>

--- a/src/app/components/asteroid-detail/asteroid-detail.component.html
+++ b/src/app/components/asteroid-detail/asteroid-detail.component.html
@@ -42,5 +42,44 @@
         </div>
       </mat-card-content>
     </mat-card>
+
+    <mat-card class="tags-card">
+      <mat-card-header>
+        <mat-card-title>Tags</mat-card-title>
+      </mat-card-header>
+      <mat-card-content>
+        <mat-chip-set class="tags-chip-set">
+          @for (tag of asteroid.tags; track tag.tag_id) {
+            <mat-chip [style.background-color]="tag.color ?? undefined" [disabled]="tagBusy"
+                      (removed)="removeTag(tag)">
+              {{ tag.name }}
+              <button matChipRemove [attr.aria-label]="'Remove tag ' + tag.name" [disabled]="tagBusy">
+                <mat-icon>cancel</mat-icon>
+              </button>
+            </mat-chip>
+          } @empty {
+            <span class="no-tags">No tags yet.</span>
+          }
+        </mat-chip-set>
+
+        <div class="add-tag-form">
+          <mat-form-field subscriptSizing="dynamic" class="add-tag-field">
+            <mat-label>Add tag</mat-label>
+            <input matInput [formControl]="newTagControl" [matAutocomplete]="tagAuto"
+                   placeholder="Pick existing or type a new tag name"
+                   (keydown.enter)="submitNewTag()">
+            <mat-autocomplete #tagAuto="matAutocomplete" (optionSelected)="onTagOptionSelected($event)">
+              @for (tag of filteredTagOptions$ | async; track tag.tag_id) {
+                <mat-option [value]="tag.name">{{ tag.name }}</mat-option>
+              }
+            </mat-autocomplete>
+          </mat-form-field>
+          <button type="button" mat-raised-button color="primary" [disabled]="tagBusy || !newTagControl.value"
+                  (click)="submitNewTag()">
+            Add
+          </button>
+        </div>
+      </mat-card-content>
+    </mat-card>
   </div>
 }

--- a/src/app/components/asteroid-detail/asteroid-detail.component.spec.ts
+++ b/src/app/components/asteroid-detail/asteroid-detail.component.spec.ts
@@ -4,7 +4,8 @@ import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { MatSnackBar } from '@angular/material/snack-bar';
 import { of, throwError } from 'rxjs';
 import { AsteroidDetailComponent } from './asteroid-detail.component';
-import { AsteroidsService, Asteroid, AsteroidTag } from '../../services/asteroids.service';
+import { AsteroidsService, Asteroid, AsteroidTag, AsteroidVisibilityResponse } from '../../services/asteroids.service';
+import { TelescopeService, Telescope } from '../../services/telescope.service';
 
 describe('AsteroidDetailComponent', () => {
   let component: AsteroidDetailComponent;
@@ -15,7 +16,9 @@ describe('AsteroidDetailComponent', () => {
     createTag: ReturnType<typeof vi.fn>;
     attachTag: ReturnType<typeof vi.fn>;
     detachTag: ReturnType<typeof vi.fn>;
+    getVisibility: ReturnType<typeof vi.fn>;
   };
+  let telescopeService: { getTelescopes: ReturnType<typeof vi.fn> };
   let router: { navigate: ReturnType<typeof vi.fn> };
   let snackBar: { open: ReturnType<typeof vi.fn> };
 
@@ -39,6 +42,30 @@ describe('AsteroidDetailComponent', () => {
     tags: [neoTag]
   };
 
+  const activeScope: Telescope = {
+    scope_id: 1, name: 'Active scope', descr: '', min_dec: -90, max_dec: 90,
+    focal: 1000, aperture: 200, lon: 21, lat: 52.2, alt: 100, sensor: null, active: true
+  };
+  const inactiveScope: Telescope = { ...activeScope, scope_id: 2, name: 'Inactive scope', active: false };
+
+  const visibleResponse: AsteroidVisibilityResponse = {
+    status: true,
+    scope_id: 1,
+    scope_name: 'Active scope',
+    night_start: '2026-07-19 20:00:00.000',
+    night_end: '2026-07-20 04:00:00.000',
+    samples: [
+      { time: '2026-07-19 20:00:00.000', altitude_deg: 10, azimuth_deg: 90, apparent_magnitude: 9.1 },
+      { time: '2026-07-20 00:00:00.000', altitude_deg: 45, azimuth_deg: 180, apparent_magnitude: 8.8 },
+      { time: '2026-07-20 04:00:00.000', altitude_deg: 5, azimuth_deg: 270, apparent_magnitude: 9.3 }
+    ],
+    max_altitude_deg: 45,
+    max_altitude_time: '2026-07-20 00:00:00.000',
+    apparent_magnitude_at_max: 8.8,
+    visible: true,
+    has_magnitude_estimate: true
+  };
+
   function makeAsteroidsService(overrides: Partial<typeof asteroidsService> = {}) {
     return {
       getAsteroid: vi.fn().mockReturnValue(of({ status: true, asteroid: { ...mockAsteroid, tags: [neoTag] }, msg: 'OK' })),
@@ -46,12 +73,18 @@ describe('AsteroidDetailComponent', () => {
       createTag: vi.fn(),
       attachTag: vi.fn(),
       detachTag: vi.fn(),
+      getVisibility: vi.fn().mockReturnValue(of(visibleResponse)),
       ...overrides
     };
   }
 
-  async function setup(id: string | null, overrides: Partial<typeof asteroidsService> = {}): Promise<void> {
+  async function setup(
+    id: string | null,
+    overrides: Partial<typeof asteroidsService> = {},
+    telescopes: Telescope[] = [activeScope, inactiveScope]
+  ): Promise<void> {
     asteroidsService = makeAsteroidsService(overrides);
+    telescopeService = { getTelescopes: vi.fn().mockReturnValue(of(telescopes)) };
     router = { navigate: vi.fn() };
     snackBar = { open: vi.fn() };
 
@@ -59,6 +92,7 @@ describe('AsteroidDetailComponent', () => {
       imports: [NoopAnimationsModule, AsteroidDetailComponent],
       providers: [
         { provide: AsteroidsService, useValue: asteroidsService },
+        { provide: TelescopeService, useValue: telescopeService },
         { provide: Router, useValue: router },
         { provide: MatSnackBar, useValue: snackBar },
         {
@@ -151,5 +185,64 @@ describe('AsteroidDetailComponent', () => {
     component.submitNewTag();
     expect(asteroidsService.createTag).not.toHaveBeenCalled();
     expect(asteroidsService.attachTag).not.toHaveBeenCalled();
+  });
+
+  it('should only offer active telescopes', async () => {
+    await setup('1');
+    expect(component.activeTelescopes).toEqual([activeScope]);
+  });
+
+  it('should not compute visibility until a telescope is selected', async () => {
+    await setup('1');
+    expect(asteroidsService.getVisibility).not.toHaveBeenCalled();
+    expect(component.visibility).toBeNull();
+  });
+
+  it('should compute visibility when a telescope is selected', async () => {
+    await setup('1');
+    component.onScopeChange(1);
+    expect(asteroidsService.getVisibility).toHaveBeenCalledWith(
+      1, expect.objectContaining({ scopeId: 1 })
+    );
+    expect(component.visibility).toEqual(visibleResponse);
+    expect(component.visibilityLoading).toBe(false);
+  });
+
+  it('should recompute visibility when the date changes', async () => {
+    await setup('1');
+    component.onScopeChange(1);
+    asteroidsService.getVisibility.mockClear();
+    component.onDateChange(new Date(2026, 0, 15));
+    expect(asteroidsService.getVisibility).toHaveBeenCalledWith(
+      1, expect.objectContaining({ scopeId: 1, date: '2026-01-15' })
+    );
+  });
+
+  it('should report a visibility error from the backend', async () => {
+    await setup('1', {
+      getVisibility: vi.fn().mockReturnValue(throwError(() => ({ error: { message: 'Telescope not found.' } })))
+    });
+    component.onScopeChange(1);
+    expect(component.visibility).toBeNull();
+    expect(component.visibilityError).toBe('Telescope not found.');
+  });
+
+  it('should compute chart geometry for the max-altitude sample', async () => {
+    await setup('1');
+    component.onScopeChange(1);
+    expect(component.maxPoint).not.toBeNull();
+    expect(component.maxPoint?.x).toBeCloseTo(300, 0); // middle sample of 3
+    expect(component.chartPolylinePoints.split(' ').length).toBe(3);
+  });
+
+  it('should surface the not-visible case distinctly', async () => {
+    const notVisible: AsteroidVisibilityResponse = {
+      ...visibleResponse,
+      visible: false,
+      max_altitude_deg: -5
+    };
+    await setup('1', { getVisibility: vi.fn().mockReturnValue(of(notVisible)) });
+    component.onScopeChange(1);
+    expect(component.visibility?.visible).toBe(false);
   });
 });

--- a/src/app/components/asteroid-detail/asteroid-detail.component.spec.ts
+++ b/src/app/components/asteroid-detail/asteroid-detail.component.spec.ts
@@ -44,7 +44,8 @@ describe('AsteroidDetailComponent', () => {
 
   const activeScope: Telescope = {
     scope_id: 1, name: 'Active scope', descr: '', min_dec: -90, max_dec: 90,
-    focal: 1000, aperture: 200, lon: 21, lat: 52.2, alt: 100, sensor: null, active: true
+    focal: 1000, aperture: 200, lon: 21, lat: 52.2, alt: 100, default_rotation: null,
+    sensor: null, active: true
   };
   const inactiveScope: Telescope = { ...activeScope, scope_id: 2, name: 'Inactive scope', active: false };
 

--- a/src/app/components/asteroid-detail/asteroid-detail.component.spec.ts
+++ b/src/app/components/asteroid-detail/asteroid-detail.component.spec.ts
@@ -4,13 +4,23 @@ import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { MatSnackBar } from '@angular/material/snack-bar';
 import { of, throwError } from 'rxjs';
 import { AsteroidDetailComponent } from './asteroid-detail.component';
-import { AsteroidsService, Asteroid } from '../../services/asteroids.service';
+import { AsteroidsService, Asteroid, AsteroidTag } from '../../services/asteroids.service';
 
 describe('AsteroidDetailComponent', () => {
   let component: AsteroidDetailComponent;
   let fixture: ComponentFixture<AsteroidDetailComponent>;
-  let asteroidsService: { getAsteroid: ReturnType<typeof vi.fn> };
+  let asteroidsService: {
+    getAsteroid: ReturnType<typeof vi.fn>;
+    listTags: ReturnType<typeof vi.fn>;
+    createTag: ReturnType<typeof vi.fn>;
+    attachTag: ReturnType<typeof vi.fn>;
+    detachTag: ReturnType<typeof vi.fn>;
+  };
   let router: { navigate: ReturnType<typeof vi.fn> };
+  let snackBar: { open: ReturnType<typeof vi.fn> };
+
+  const neoTag: AsteroidTag = { tag_id: 1, name: 'neo', description: null, color: '#e53935' };
+  const phaTag: AsteroidTag = { tag_id: 2, name: 'pha', description: null, color: null };
 
   const mockAsteroid: Asteroid = {
     asteroid_id: 1,
@@ -25,21 +35,32 @@ describe('AsteroidDetailComponent', () => {
     mean_motion: 0.214,
     semimajor_axis: 2.77,
     absolute_magnitude: 3.34,
-    slope_parameter: 0.12
+    slope_parameter: 0.12,
+    tags: [neoTag]
   };
 
-  async function setup(id: string | null): Promise<void> {
-    asteroidsService = {
-      getAsteroid: vi.fn().mockReturnValue(of({ status: true, asteroid: mockAsteroid, msg: 'OK' }))
+  function makeAsteroidsService(overrides: Partial<typeof asteroidsService> = {}) {
+    return {
+      getAsteroid: vi.fn().mockReturnValue(of({ status: true, asteroid: { ...mockAsteroid, tags: [neoTag] }, msg: 'OK' })),
+      listTags: vi.fn().mockReturnValue(of([neoTag, phaTag])),
+      createTag: vi.fn(),
+      attachTag: vi.fn(),
+      detachTag: vi.fn(),
+      ...overrides
     };
+  }
+
+  async function setup(id: string | null, overrides: Partial<typeof asteroidsService> = {}): Promise<void> {
+    asteroidsService = makeAsteroidsService(overrides);
     router = { navigate: vi.fn() };
+    snackBar = { open: vi.fn() };
 
     await TestBed.configureTestingModule({
       imports: [NoopAnimationsModule, AsteroidDetailComponent],
       providers: [
         { provide: AsteroidsService, useValue: asteroidsService },
         { provide: Router, useValue: router },
-        { provide: MatSnackBar, useValue: { open: vi.fn() } },
+        { provide: MatSnackBar, useValue: snackBar },
         {
           provide: ActivatedRoute,
           useValue: { snapshot: { paramMap: { get: () => id } } }
@@ -56,7 +77,8 @@ describe('AsteroidDetailComponent', () => {
     await setup('1');
     expect(component).toBeTruthy();
     expect(asteroidsService.getAsteroid).toHaveBeenCalledWith(1);
-    expect(component.asteroid).toEqual(mockAsteroid);
+    expect(component.asteroid?.designation).toBe('00001');
+    expect(component.availableTags).toEqual([neoTag, phaTag]);
   });
 
   it('should flag not found when no id is present in the route', async () => {
@@ -66,27 +88,7 @@ describe('AsteroidDetailComponent', () => {
   });
 
   it('should flag not found when the request fails', async () => {
-    asteroidsService = {
-      getAsteroid: vi.fn().mockReturnValue(throwError(() => new Error('404')))
-    };
-    router = { navigate: vi.fn() };
-    await TestBed.configureTestingModule({
-      imports: [NoopAnimationsModule, AsteroidDetailComponent],
-      providers: [
-        { provide: AsteroidsService, useValue: asteroidsService },
-        { provide: Router, useValue: router },
-        { provide: MatSnackBar, useValue: { open: vi.fn() } },
-        {
-          provide: ActivatedRoute,
-          useValue: { snapshot: { paramMap: { get: () => '999' } } }
-        }
-      ]
-    }).compileComponents();
-
-    fixture = TestBed.createComponent(AsteroidDetailComponent);
-    component = fixture.componentInstance;
-    fixture.detectChanges();
-
+    await setup('999', { getAsteroid: vi.fn().mockReturnValue(throwError(() => new Error('404'))) });
     expect(component.notFound).toBe(true);
   });
 
@@ -97,31 +99,57 @@ describe('AsteroidDetailComponent', () => {
   });
 
   it('should report provisional asteroids as such', async () => {
-    asteroidsService = {
-      getAsteroid: vi.fn().mockReturnValue(of({
-        status: true,
-        asteroid: { ...mockAsteroid, number: null },
-        msg: 'OK'
-      }))
-    };
-    router = { navigate: vi.fn() };
-    await TestBed.configureTestingModule({
-      imports: [NoopAnimationsModule, AsteroidDetailComponent],
-      providers: [
-        { provide: AsteroidsService, useValue: asteroidsService },
-        { provide: Router, useValue: router },
-        { provide: MatSnackBar, useValue: { open: vi.fn() } },
-        {
-          provide: ActivatedRoute,
-          useValue: { snapshot: { paramMap: { get: () => '2' } } }
-        }
-      ]
-    }).compileComponents();
-
-    fixture = TestBed.createComponent(AsteroidDetailComponent);
-    component = fixture.componentInstance;
-    fixture.detectChanges();
-
+    await setup('2', {
+      getAsteroid: vi.fn().mockReturnValue(of({ status: true, asteroid: { ...mockAsteroid, number: null }, msg: 'OK' }))
+    });
     expect(component.isProvisional()).toBe(true);
+  });
+
+  it('should attach an existing tag by name without creating a duplicate', async () => {
+    await setup('1', { attachTag: vi.fn().mockReturnValue(of({ status: true, msg: 'Tag added' })) });
+    component.newTagControl.setValue('pha');
+    component.submitNewTag();
+    expect(asteroidsService.createTag).not.toHaveBeenCalled();
+    expect(asteroidsService.attachTag).toHaveBeenCalledWith(1, phaTag.tag_id);
+    expect(component.asteroid?.tags).toContainEqual(phaTag);
+    expect(component.newTagControl.value).toBe('');
+  });
+
+  it('should create and attach a brand-new tag', async () => {
+    const fastRotator: AsteroidTag = { tag_id: 3, name: 'fast rotator', description: null, color: null };
+    await setup('1', {
+      createTag: vi.fn().mockReturnValue(of({ status: true, tag_id: 3, tag: fastRotator, msg: 'Tag created successfully.' })),
+      attachTag: vi.fn().mockReturnValue(of({ status: true, msg: 'Tag added' }))
+    });
+    component.newTagControl.setValue('fast rotator');
+    component.submitNewTag();
+    expect(asteroidsService.createTag).toHaveBeenCalledWith({ name: 'fast rotator' });
+    expect(asteroidsService.attachTag).toHaveBeenCalledWith(1, 3);
+    expect(component.asteroid?.tags).toContainEqual(fastRotator);
+    expect(component.availableTags).toContainEqual(fastRotator);
+  });
+
+  it('should show an error and not attach when the backend rejects the tag', async () => {
+    await setup('1', { attachTag: vi.fn().mockReturnValue(of({ status: false, msg: 'Asteroid or tag not found' })) });
+    component.newTagControl.setValue('pha');
+    component.submitNewTag();
+    expect(snackBar.open).toHaveBeenCalledWith('Asteroid or tag not found', 'Close', expect.anything());
+    expect(component.asteroid?.tags).not.toContainEqual(phaTag);
+  });
+
+  it('should remove a tag', async () => {
+    await setup('1', { detachTag: vi.fn().mockReturnValue(of({ status: true, msg: 'Tag removed' })) });
+    expect(component.asteroid?.tags).toContainEqual(neoTag);
+    component.removeTag(neoTag);
+    expect(asteroidsService.detachTag).toHaveBeenCalledWith(1, neoTag.tag_id);
+    expect(component.asteroid?.tags).not.toContainEqual(neoTag);
+  });
+
+  it('should not submit an empty tag name', async () => {
+    await setup('1');
+    component.newTagControl.setValue('   ');
+    component.submitNewTag();
+    expect(asteroidsService.createTag).not.toHaveBeenCalled();
+    expect(asteroidsService.attachTag).not.toHaveBeenCalled();
   });
 });

--- a/src/app/components/asteroid-detail/asteroid-detail.component.spec.ts
+++ b/src/app/components/asteroid-detail/asteroid-detail.component.spec.ts
@@ -1,0 +1,127 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { ActivatedRoute, Router } from '@angular/router';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+import { MatSnackBar } from '@angular/material/snack-bar';
+import { of, throwError } from 'rxjs';
+import { AsteroidDetailComponent } from './asteroid-detail.component';
+import { AsteroidsService, Asteroid } from '../../services/asteroids.service';
+
+describe('AsteroidDetailComponent', () => {
+  let component: AsteroidDetailComponent;
+  let fixture: ComponentFixture<AsteroidDetailComponent>;
+  let asteroidsService: { getAsteroid: ReturnType<typeof vi.fn> };
+  let router: { navigate: ReturnType<typeof vi.fn> };
+
+  const mockAsteroid: Asteroid = {
+    asteroid_id: 1,
+    number: 1,
+    designation: '00001',
+    epoch: 'K25A2',
+    mean_anomaly: 10.5,
+    perihelion_arg: 73.6,
+    ascending_node: 80.3,
+    inclination: 10.6,
+    eccentricity: 0.078,
+    mean_motion: 0.214,
+    semimajor_axis: 2.77,
+    absolute_magnitude: 3.34,
+    slope_parameter: 0.12
+  };
+
+  async function setup(id: string | null): Promise<void> {
+    asteroidsService = {
+      getAsteroid: vi.fn().mockReturnValue(of({ status: true, asteroid: mockAsteroid, msg: 'OK' }))
+    };
+    router = { navigate: vi.fn() };
+
+    await TestBed.configureTestingModule({
+      imports: [NoopAnimationsModule, AsteroidDetailComponent],
+      providers: [
+        { provide: AsteroidsService, useValue: asteroidsService },
+        { provide: Router, useValue: router },
+        { provide: MatSnackBar, useValue: { open: vi.fn() } },
+        {
+          provide: ActivatedRoute,
+          useValue: { snapshot: { paramMap: { get: () => id } } }
+        }
+      ]
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(AsteroidDetailComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  }
+
+  it('should create and load the asteroid by route id', async () => {
+    await setup('1');
+    expect(component).toBeTruthy();
+    expect(asteroidsService.getAsteroid).toHaveBeenCalledWith(1);
+    expect(component.asteroid).toEqual(mockAsteroid);
+  });
+
+  it('should flag not found when no id is present in the route', async () => {
+    await setup(null);
+    expect(component.notFound).toBe(true);
+    expect(asteroidsService.getAsteroid).not.toHaveBeenCalled();
+  });
+
+  it('should flag not found when the request fails', async () => {
+    asteroidsService = {
+      getAsteroid: vi.fn().mockReturnValue(throwError(() => new Error('404')))
+    };
+    router = { navigate: vi.fn() };
+    await TestBed.configureTestingModule({
+      imports: [NoopAnimationsModule, AsteroidDetailComponent],
+      providers: [
+        { provide: AsteroidsService, useValue: asteroidsService },
+        { provide: Router, useValue: router },
+        { provide: MatSnackBar, useValue: { open: vi.fn() } },
+        {
+          provide: ActivatedRoute,
+          useValue: { snapshot: { paramMap: { get: () => '999' } } }
+        }
+      ]
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(AsteroidDetailComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+
+    expect(component.notFound).toBe(true);
+  });
+
+  it('should navigate back to the list', async () => {
+    await setup('1');
+    component.backToList();
+    expect(router.navigate).toHaveBeenCalledWith(['/asteroids']);
+  });
+
+  it('should report provisional asteroids as such', async () => {
+    asteroidsService = {
+      getAsteroid: vi.fn().mockReturnValue(of({
+        status: true,
+        asteroid: { ...mockAsteroid, number: null },
+        msg: 'OK'
+      }))
+    };
+    router = { navigate: vi.fn() };
+    await TestBed.configureTestingModule({
+      imports: [NoopAnimationsModule, AsteroidDetailComponent],
+      providers: [
+        { provide: AsteroidsService, useValue: asteroidsService },
+        { provide: Router, useValue: router },
+        { provide: MatSnackBar, useValue: { open: vi.fn() } },
+        {
+          provide: ActivatedRoute,
+          useValue: { snapshot: { paramMap: { get: () => '2' } } }
+        }
+      ]
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(AsteroidDetailComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+
+    expect(component.isProvisional()).toBe(true);
+  });
+});

--- a/src/app/components/asteroid-detail/asteroid-detail.component.ts
+++ b/src/app/components/asteroid-detail/asteroid-detail.component.ts
@@ -1,10 +1,18 @@
 import { Component, OnInit, inject } from '@angular/core';
+import { AsyncPipe } from '@angular/common';
 import { ActivatedRoute, Router } from '@angular/router';
-import { AsteroidsService, Asteroid } from '../../services/asteroids.service';
+import { AsteroidsService, Asteroid, AsteroidTag } from '../../services/asteroids.service';
 import { MatCardModule } from '@angular/material/card';
 import { MatButtonModule } from '@angular/material/button';
 import { MatIconModule } from '@angular/material/icon';
+import { MatChipsModule } from '@angular/material/chips';
+import { MatFormFieldModule } from '@angular/material/form-field';
+import { MatInputModule } from '@angular/material/input';
+import { MatAutocompleteModule, MatAutocompleteSelectedEvent } from '@angular/material/autocomplete';
 import { MatSnackBar } from '@angular/material/snack-bar';
+import { FormControl, ReactiveFormsModule } from '@angular/forms';
+import { Observable } from 'rxjs';
+import { map, startWith } from 'rxjs/operators';
 
 @Component({
   selector: 'app-asteroid-detail',
@@ -13,7 +21,13 @@ import { MatSnackBar } from '@angular/material/snack-bar';
   imports: [
     MatCardModule,
     MatButtonModule,
-    MatIconModule
+    MatIconModule,
+    MatChipsModule,
+    MatFormFieldModule,
+    MatInputModule,
+    MatAutocompleteModule,
+    ReactiveFormsModule,
+    AsyncPipe
   ]
 })
 export class AsteroidDetailComponent implements OnInit {
@@ -24,8 +38,33 @@ export class AsteroidDetailComponent implements OnInit {
 
   asteroid: Asteroid | null = null;
   notFound = false;
+  availableTags: AsteroidTag[] = [];
+  tagBusy = false;
+
+  newTagControl = new FormControl('');
+  filteredTagOptions$: Observable<AsteroidTag[]>;
+
+  constructor() {
+    this.filteredTagOptions$ = this.newTagControl.valueChanges.pipe(
+      startWith(''),
+      map(value => this.filterTagOptions(value ?? ''))
+    );
+  }
+
+  private filterTagOptions(value: string): AsteroidTag[] {
+    const attachedIds = new Set((this.asteroid?.tags ?? []).map(t => t.tag_id));
+    const query = value.trim().toLowerCase();
+    return this.availableTags
+      .filter(tag => !attachedIds.has(tag.tag_id))
+      .filter(tag => !query || tag.name.toLowerCase().includes(query));
+  }
 
   ngOnInit(): void {
+    this.asteroidsService.listTags().subscribe({
+      next: tags => { this.availableTags = tags; },
+      error: () => { this.availableTags = []; }
+    });
+
     const id = this.route.snapshot.paramMap.get('id');
     if (id) {
       this.loadAsteroid(Number(id));
@@ -53,5 +92,75 @@ export class AsteroidDetailComponent implements OnInit {
   /** MPC designations that don't have an assigned number are provisional. */
   isProvisional(): boolean {
     return this.asteroid?.number == null;
+  }
+
+  onTagOptionSelected(event: MatAutocompleteSelectedEvent): void {
+    const tag = this.availableTags.find(t => t.name === event.option.value);
+    if (tag) {
+      this.addExistingTag(tag);
+    }
+  }
+
+  /** Add the typed tag: attaches it if it already exists, otherwise creates it first. */
+  submitNewTag(): void {
+    const name = (this.newTagControl.value ?? '').trim();
+    if (!name || !this.asteroid || this.tagBusy) return;
+
+    const existing = this.availableTags.find(t => t.name.toLowerCase() === name.toLowerCase());
+    if (existing) {
+      this.addExistingTag(existing);
+      return;
+    }
+
+    this.tagBusy = true;
+    this.asteroidsService.createTag({ name }).subscribe({
+      next: response => {
+        this.availableTags = [...this.availableTags, response.tag];
+        this.addExistingTag(response.tag);
+      },
+      error: err => {
+        this.tagBusy = false;
+        this.snackBar.open(err?.error?.message || err?.error?.msg || 'Failed to create tag', 'Close', { duration: 4000 });
+      }
+    });
+  }
+
+  private addExistingTag(tag: AsteroidTag): void {
+    if (!this.asteroid) return;
+    this.tagBusy = true;
+    this.asteroidsService.attachTag(this.asteroid.asteroid_id, tag.tag_id).subscribe({
+      next: response => {
+        this.tagBusy = false;
+        if (!response.status) {
+          this.snackBar.open(response.msg || 'Failed to add tag', 'Close', { duration: 4000 });
+          return;
+        }
+        if (this.asteroid && !this.asteroid.tags.some(t => t.tag_id === tag.tag_id)) {
+          this.asteroid.tags = [...this.asteroid.tags, tag];
+        }
+        this.newTagControl.setValue('');
+      },
+      error: () => {
+        this.tagBusy = false;
+        this.snackBar.open('Failed to add tag', 'Close', { duration: 4000 });
+      }
+    });
+  }
+
+  removeTag(tag: AsteroidTag): void {
+    if (!this.asteroid || this.tagBusy) return;
+    this.tagBusy = true;
+    this.asteroidsService.detachTag(this.asteroid.asteroid_id, tag.tag_id).subscribe({
+      next: () => {
+        this.tagBusy = false;
+        if (this.asteroid) {
+          this.asteroid.tags = this.asteroid.tags.filter(t => t.tag_id !== tag.tag_id);
+        }
+      },
+      error: () => {
+        this.tagBusy = false;
+        this.snackBar.open('Failed to remove tag', 'Close', { duration: 4000 });
+      }
+    });
   }
 }

--- a/src/app/components/asteroid-detail/asteroid-detail.component.ts
+++ b/src/app/components/asteroid-detail/asteroid-detail.component.ts
@@ -1,0 +1,57 @@
+import { Component, OnInit, inject } from '@angular/core';
+import { ActivatedRoute, Router } from '@angular/router';
+import { AsteroidsService, Asteroid } from '../../services/asteroids.service';
+import { MatCardModule } from '@angular/material/card';
+import { MatButtonModule } from '@angular/material/button';
+import { MatIconModule } from '@angular/material/icon';
+import { MatSnackBar } from '@angular/material/snack-bar';
+
+@Component({
+  selector: 'app-asteroid-detail',
+  templateUrl: './asteroid-detail.component.html',
+  styleUrls: ['./asteroid-detail.component.css'],
+  imports: [
+    MatCardModule,
+    MatButtonModule,
+    MatIconModule
+  ]
+})
+export class AsteroidDetailComponent implements OnInit {
+  private route = inject(ActivatedRoute);
+  private router = inject(Router);
+  private asteroidsService = inject(AsteroidsService);
+  private snackBar = inject(MatSnackBar);
+
+  asteroid: Asteroid | null = null;
+  notFound = false;
+
+  ngOnInit(): void {
+    const id = this.route.snapshot.paramMap.get('id');
+    if (id) {
+      this.loadAsteroid(Number(id));
+    } else {
+      this.notFound = true;
+    }
+  }
+
+  loadAsteroid(asteroidId: number): void {
+    this.asteroidsService.getAsteroid(asteroidId).subscribe({
+      next: response => {
+        this.asteroid = response.asteroid;
+      },
+      error: () => {
+        this.notFound = true;
+        this.snackBar.open('Asteroid not found', 'Close', { duration: 3000 });
+      }
+    });
+  }
+
+  backToList(): void {
+    this.router.navigate(['/asteroids']);
+  }
+
+  /** MPC designations that don't have an assigned number are provisional. */
+  isProvisional(): boolean {
+    return this.asteroid?.number == null;
+  }
+}

--- a/src/app/components/asteroid-detail/asteroid-detail.component.ts
+++ b/src/app/components/asteroid-detail/asteroid-detail.component.ts
@@ -1,13 +1,23 @@
 import { Component, OnInit, inject } from '@angular/core';
-import { AsyncPipe } from '@angular/common';
+import { AsyncPipe, DatePipe } from '@angular/common';
 import { ActivatedRoute, Router } from '@angular/router';
-import { AsteroidsService, Asteroid, AsteroidTag } from '../../services/asteroids.service';
+import {
+  AsteroidsService,
+  Asteroid,
+  AsteroidTag,
+  AsteroidVisibilityResponse
+} from '../../services/asteroids.service';
+import { TelescopeService, Telescope } from '../../services/telescope.service';
 import { MatCardModule } from '@angular/material/card';
 import { MatButtonModule } from '@angular/material/button';
 import { MatIconModule } from '@angular/material/icon';
 import { MatChipsModule } from '@angular/material/chips';
 import { MatFormFieldModule } from '@angular/material/form-field';
 import { MatInputModule } from '@angular/material/input';
+import { MatSelectModule } from '@angular/material/select';
+import { MatDatepickerModule } from '@angular/material/datepicker';
+import { MatNativeDateModule } from '@angular/material/core';
+import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
 import { MatAutocompleteModule, MatAutocompleteSelectedEvent } from '@angular/material/autocomplete';
 import { MatSnackBar } from '@angular/material/snack-bar';
 import { FormControl, ReactiveFormsModule } from '@angular/forms';
@@ -25,15 +35,21 @@ import { map, startWith } from 'rxjs/operators';
     MatChipsModule,
     MatFormFieldModule,
     MatInputModule,
+    MatSelectModule,
+    MatDatepickerModule,
+    MatNativeDateModule,
+    MatProgressSpinnerModule,
     MatAutocompleteModule,
     ReactiveFormsModule,
-    AsyncPipe
+    AsyncPipe,
+    DatePipe
   ]
 })
 export class AsteroidDetailComponent implements OnInit {
   private route = inject(ActivatedRoute);
   private router = inject(Router);
   private asteroidsService = inject(AsteroidsService);
+  private telescopeService = inject(TelescopeService);
   private snackBar = inject(MatSnackBar);
 
   asteroid: Asteroid | null = null;
@@ -43,6 +59,23 @@ export class AsteroidDetailComponent implements OnInit {
 
   newTagControl = new FormControl('');
   filteredTagOptions$: Observable<AsteroidTag[]>;
+
+  // Visibility widget
+  private readonly CHART_WIDTH = 600;
+  private readonly CHART_HEIGHT = 200;
+  private readonly ALT_MIN = -20;
+  private readonly ALT_MAX = 90;
+
+  telescopes: Telescope[] = [];
+  scopeControl = new FormControl<number | null>(null);
+  dateControl = new FormControl<Date>(new Date());
+  visibility: AsteroidVisibilityResponse | null = null;
+  visibilityLoading = false;
+  visibilityError: string | null = null;
+
+  get activeTelescopes(): Telescope[] {
+    return this.telescopes.filter(t => t.active);
+  }
 
   constructor() {
     this.filteredTagOptions$ = this.newTagControl.valueChanges.pipe(
@@ -63,6 +96,11 @@ export class AsteroidDetailComponent implements OnInit {
     this.asteroidsService.listTags().subscribe({
       next: tags => { this.availableTags = tags; },
       error: () => { this.availableTags = []; }
+    });
+
+    this.telescopeService.getTelescopes().subscribe({
+      next: telescopes => { this.telescopes = telescopes; },
+      error: () => { this.telescopes = []; }
     });
 
     const id = this.route.snapshot.paramMap.get('id');
@@ -162,5 +200,86 @@ export class AsteroidDetailComponent implements OnInit {
         this.snackBar.open('Failed to remove tag', 'Close', { duration: 4000 });
       }
     });
+  }
+
+  onScopeChange(scopeId: number | null): void {
+    this.scopeControl.setValue(scopeId);
+    this.loadVisibility();
+  }
+
+  onDateChange(newDate: Date | null): void {
+    this.dateControl.setValue(newDate ?? new Date());
+    this.loadVisibility();
+  }
+
+  loadVisibility(): void {
+    const scopeId = this.scopeControl.value;
+    if (!this.asteroid || scopeId == null) {
+      this.visibility = null;
+      return;
+    }
+    this.visibilityLoading = true;
+    this.visibilityError = null;
+    this.asteroidsService.getVisibility(this.asteroid.asteroid_id, {
+      scopeId,
+      date: this.formatDateForApi(this.dateControl.value ?? new Date())
+    }).subscribe({
+      next: response => {
+        this.visibilityLoading = false;
+        this.visibility = response;
+      },
+      error: err => {
+        this.visibilityLoading = false;
+        this.visibility = null;
+        this.visibilityError = err?.error?.message || err?.error?.msg || 'Could not compute visibility.';
+      }
+    });
+  }
+
+  private formatDateForApi(d: Date): string {
+    const year = d.getFullYear();
+    const month = String(d.getMonth() + 1).padStart(2, '0');
+    const day = String(d.getDate()).padStart(2, '0');
+    return `${year}-${month}-${day}`;
+  }
+
+  /** HH:MM extracted from a "YYYY-MM-DD HH:MM:SS.sss" UTC timestamp. */
+  formatTimeLabel(iso: string): string {
+    const match = iso.match(/(\d{2}):(\d{2})/);
+    return match ? `${match[1]}:${match[2]}` : iso;
+  }
+
+  private altToY(altitudeDeg: number): number {
+    const clamped = Math.max(this.ALT_MIN, Math.min(this.ALT_MAX, altitudeDeg));
+    const frac = (clamped - this.ALT_MIN) / (this.ALT_MAX - this.ALT_MIN);
+    return this.CHART_HEIGHT - frac * this.CHART_HEIGHT;
+  }
+
+  get chartViewBox(): string {
+    return `0 0 ${this.CHART_WIDTH} ${this.CHART_HEIGHT}`;
+  }
+
+  get horizonY(): number {
+    return this.altToY(0);
+  }
+
+  get chartPolylinePoints(): string {
+    if (!this.visibility || this.visibility.samples.length === 0) return '';
+    const n = this.visibility.samples.length;
+    return this.visibility.samples
+      .map((s, i) => {
+        const x = n > 1 ? (i / (n - 1)) * this.CHART_WIDTH : 0;
+        return `${x.toFixed(1)},${this.altToY(s.altitude_deg).toFixed(1)}`;
+      })
+      .join(' ');
+  }
+
+  get maxPoint(): { x: number; y: number } | null {
+    if (!this.visibility || this.visibility.samples.length === 0) return null;
+    const n = this.visibility.samples.length;
+    const idx = this.visibility.samples.findIndex(s => s.time === this.visibility!.max_altitude_time);
+    if (idx < 0) return null;
+    const x = n > 1 ? (idx / (n - 1)) * this.CHART_WIDTH : 0;
+    return { x, y: this.altToY(this.visibility.samples[idx].altitude_deg) };
   }
 }

--- a/src/app/components/asteroids-list/asteroids-list.component.css
+++ b/src/app/components/asteroids-list/asteroids-list.component.css
@@ -1,0 +1,180 @@
+.container {
+  padding: 20px;
+}
+
+.filters {
+  margin-bottom: 20px;
+  overflow: hidden;
+  background-color: #f5f5f5;
+  border-radius: 4px;
+}
+
+.filter-form {
+  display: flex;
+  gap: 10px;
+  flex-wrap: wrap;
+  padding: 10px;
+  align-items: flex-start;
+}
+
+.filter-field {
+  flex: 1 1 180px;
+  min-width: 140px;
+}
+
+.filter-field-narrow {
+  flex: 1 1 100px;
+  min-width: 90px;
+}
+
+.mag-filters {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  align-items: center;
+  flex: 1 1 100%;
+  width: 100%;
+}
+
+.mag-label {
+  flex: 0 0 100%;
+  font-size: 0.85rem;
+  color: #616161;
+  margin: 0;
+}
+
+.filter-error {
+  flex: 1 1 100%;
+  margin: 0;
+  color: #c62828;
+  font-size: 0.875rem;
+}
+
+.filter-actions {
+  display: flex;
+  gap: 10px;
+  align-items: center;
+  margin-left: auto;
+  flex: 1 1 auto;
+  justify-content: flex-end;
+}
+
+.table-container {
+  overflow-x: auto;
+}
+
+table {
+  width: 100%;
+}
+
+.asteroid-row {
+  cursor: pointer;
+}
+
+.asteroid-row:hover {
+  background-color: #f5f5f5;
+}
+
+.paginator {
+  margin-top: 8px;
+}
+
+.mat-column-number {
+  min-width: 90px;
+}
+
+.mat-column-designation {
+  min-width: 130px;
+}
+
+.mat-column-absolute_magnitude,
+.mat-column-eccentricity {
+  min-width: 110px;
+}
+
+.mat-column-semimajor_axis {
+  min-width: 150px;
+}
+
+.mat-column-inclination {
+  min-width: 110px;
+}
+
+.mobile-cards {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.asteroid-card {
+  background: #fff;
+  border: 1px solid #e0e0e0;
+  border-radius: 6px;
+  padding: 12px 14px;
+  cursor: pointer;
+}
+
+.card-line1 {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: 8px;
+}
+
+.card-designation {
+  font-weight: 500;
+  font-size: 1rem;
+}
+
+.card-number {
+  font-size: 0.85rem;
+  color: #616161;
+  flex-shrink: 0;
+}
+
+.card-line2 {
+  margin-top: 4px;
+  font-size: 0.85rem;
+  color: #555;
+}
+
+.no-results {
+  padding: 24px;
+  text-align: center;
+  color: #757575;
+}
+
+@media (max-width: 640px) {
+  .container {
+    padding: 8px 4px;
+  }
+
+  .filters {
+    margin-bottom: 12px;
+  }
+
+  .filter-form {
+    padding: 8px;
+    gap: 8px;
+  }
+
+  .filter-field,
+  .filter-field-narrow {
+    flex: 1 1 100%;
+    min-width: 0;
+  }
+
+  .filter-actions {
+    width: 100%;
+    margin-left: 0;
+    justify-content: stretch;
+  }
+
+  .filter-actions button {
+    flex: 1;
+  }
+
+  .table-container {
+    overflow-x: hidden;
+  }
+}

--- a/src/app/components/asteroids-list/asteroids-list.component.css
+++ b/src/app/components/asteroids-list/asteroids-list.component.css
@@ -43,6 +43,15 @@
   margin: 0;
 }
 
+.tag-filters {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  align-items: flex-start;
+  flex: 1 1 100%;
+  width: 100%;
+}
+
 .filter-error {
   flex: 1 1 100%;
   margin: 0;
@@ -100,6 +109,19 @@ table {
   min-width: 110px;
 }
 
+.mat-column-tags {
+  min-width: 160px;
+}
+
+.mat-column-tags mat-chip-set,
+.card-tags {
+  --mdc-chip-container-height: 22px;
+}
+
+mat-chip {
+  font-size: 0.75rem;
+}
+
 .mobile-cards {
   display: flex;
   flex-direction: column;
@@ -136,6 +158,10 @@ table {
   margin-top: 4px;
   font-size: 0.85rem;
   color: #555;
+}
+
+.card-tags {
+  margin-top: 6px;
 }
 
 .no-results {

--- a/src/app/components/asteroids-list/asteroids-list.component.html
+++ b/src/app/components/asteroids-list/asteroids-list.component.html
@@ -32,6 +32,24 @@
         </mat-form-field>
       </div>
 
+      <div class="tag-filters">
+        <mat-form-field class="filter-field" subscriptSizing="dynamic">
+          <mat-label>Tags</mat-label>
+          <mat-select formControlName="tags" multiple>
+            @for (tag of availableTags; track tag.tag_id) {
+              <mat-option [value]="tag.name">{{ tag.name }}</mat-option>
+            }
+          </mat-select>
+        </mat-form-field>
+        <mat-form-field class="filter-field filter-field-narrow" subscriptSizing="dynamic">
+          <mat-label>Match</mat-label>
+          <mat-select formControlName="tags_mode">
+            <mat-option value="any">Any selected tag</mat-option>
+            <mat-option value="all">All selected tags</mat-option>
+          </mat-select>
+        </mat-form-field>
+      </div>
+
       @if (filterError) {
         <p class="filter-error" role="alert">{{ filterError }}</p>
       }
@@ -54,6 +72,13 @@
           <div class="card-line2">
             @if (asteroid.absolute_magnitude !== null) { H = {{ asteroid.absolute_magnitude }} }
           </div>
+          @if (asteroid.tags.length > 0) {
+            <mat-chip-set class="card-tags">
+              @for (tag of asteroid.tags; track tag.tag_id) {
+                <mat-chip [style.background-color]="tag.color ?? undefined" disableRipple>{{ tag.name }}</mat-chip>
+              }
+            </mat-chip-set>
+          }
         </div>
       } @empty {
         <div class="no-results">No asteroids match the current filters.</div>
@@ -90,6 +115,17 @@
         <ng-container matColumnDef="inclination">
           <th mat-header-cell *matHeaderCellDef mat-sort-header>Inclination (°)</th>
           <td mat-cell *matCellDef="let asteroid">{{ asteroid.inclination }}</td>
+        </ng-container>
+
+        <ng-container matColumnDef="tags">
+          <th mat-header-cell *matHeaderCellDef>Tags</th>
+          <td mat-cell *matCellDef="let asteroid" (click)="$event.stopPropagation()">
+            <mat-chip-set>
+              @for (tag of asteroid.tags; track tag.tag_id) {
+                <mat-chip [style.background-color]="tag.color ?? undefined" disableRipple>{{ tag.name }}</mat-chip>
+              }
+            </mat-chip-set>
+          </td>
         </ng-container>
 
         <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>

--- a/src/app/components/asteroids-list/asteroids-list.component.html
+++ b/src/app/components/asteroids-list/asteroids-list.component.html
@@ -1,0 +1,110 @@
+<div class="container">
+  <div class="filters" [@filterExpand]="isFilterVisible ? 'expanded' : 'collapsed'">
+    <form [formGroup]="filterForm" class="filter-form" (ngSubmit)="onFilterSubmit($event)">
+      <mat-form-field class="filter-field" subscriptSizing="dynamic">
+        <mat-label>Designation</mat-label>
+        <input matInput formControlName="designation" type="text" placeholder="e.g. 00001">
+      </mat-form-field>
+
+      <mat-form-field class="filter-field filter-field-narrow" subscriptSizing="dynamic">
+        <mat-label>Number</mat-label>
+        <input matInput formControlName="number" type="number" step="1" min="1">
+      </mat-form-field>
+
+      <mat-form-field class="filter-field" subscriptSizing="dynamic">
+        <mat-label>Numbering</mat-label>
+        <mat-select formControlName="numbered">
+          <mat-option [value]="null">All asteroids</mat-option>
+          <mat-option [value]="true">Numbered only</mat-option>
+          <mat-option [value]="false">Unnumbered / provisional only</mat-option>
+        </mat-select>
+      </mat-form-field>
+
+      <div class="mag-filters">
+        <span class="mag-label">Absolute magnitude (H)</span>
+        <mat-form-field class="filter-field filter-field-narrow" subscriptSizing="dynamic">
+          <mat-label>Min</mat-label>
+          <input matInput formControlName="mag_min" type="number" step="any">
+        </mat-form-field>
+        <mat-form-field class="filter-field filter-field-narrow" subscriptSizing="dynamic">
+          <mat-label>Max</mat-label>
+          <input matInput formControlName="mag_max" type="number" step="any">
+        </mat-form-field>
+      </div>
+
+      @if (filterError) {
+        <p class="filter-error" role="alert">{{ filterError }}</p>
+      }
+
+      <div class="filter-actions">
+        <button type="button" mat-button (click)="clearFilters()">Clear</button>
+        <button type="submit" mat-raised-button color="primary">Apply</button>
+      </div>
+    </form>
+  </div>
+
+  @if (isMobile) {
+    <div class="mobile-cards">
+      @for (asteroid of asteroids; track asteroid.asteroid_id) {
+        <div class="asteroid-card" (click)="openAsteroid(asteroid)" (keyup.enter)="openAsteroid(asteroid)" tabindex="0" role="button">
+          <div class="card-line1">
+            <span class="card-designation">{{ asteroid.designation }}</span>
+            @if (asteroid.number !== null) { <span class="card-number">#{{ asteroid.number }}</span> }
+          </div>
+          <div class="card-line2">
+            @if (asteroid.absolute_magnitude !== null) { H = {{ asteroid.absolute_magnitude }} }
+          </div>
+        </div>
+      } @empty {
+        <div class="no-results">No asteroids match the current filters.</div>
+      }
+    </div>
+  } @else {
+    <div class="table-container">
+      <table mat-table [dataSource]="asteroids" matSort (matSortChange)="onSortChange($event)" class="mat-elevation-z8">
+        <ng-container matColumnDef="number">
+          <th mat-header-cell *matHeaderCellDef mat-sort-header>Number</th>
+          <td mat-cell *matCellDef="let asteroid">{{ asteroid.number ?? '—' }}</td>
+        </ng-container>
+
+        <ng-container matColumnDef="designation">
+          <th mat-header-cell *matHeaderCellDef mat-sort-header>Designation</th>
+          <td mat-cell *matCellDef="let asteroid">{{ asteroid.designation }}</td>
+        </ng-container>
+
+        <ng-container matColumnDef="absolute_magnitude">
+          <th mat-header-cell *matHeaderCellDef mat-sort-header>Magnitude (H)</th>
+          <td mat-cell *matCellDef="let asteroid">{{ asteroid.absolute_magnitude ?? '—' }}</td>
+        </ng-container>
+
+        <ng-container matColumnDef="semimajor_axis">
+          <th mat-header-cell *matHeaderCellDef mat-sort-header>Semi-major axis (AU)</th>
+          <td mat-cell *matCellDef="let asteroid">{{ asteroid.semimajor_axis }}</td>
+        </ng-container>
+
+        <ng-container matColumnDef="eccentricity">
+          <th mat-header-cell *matHeaderCellDef mat-sort-header>Eccentricity</th>
+          <td mat-cell *matCellDef="let asteroid">{{ asteroid.eccentricity }}</td>
+        </ng-container>
+
+        <ng-container matColumnDef="inclination">
+          <th mat-header-cell *matHeaderCellDef mat-sort-header>Inclination (°)</th>
+          <td mat-cell *matCellDef="let asteroid">{{ asteroid.inclination }}</td>
+        </ng-container>
+
+        <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>
+        <tr mat-row *matRowDef="let row; columns: displayedColumns;"
+            class="asteroid-row" (click)="openAsteroid(row)"></tr>
+      </table>
+    </div>
+  }
+
+  <mat-paginator
+    class="paginator"
+    [length]="totalAsteroids"
+    [pageIndex]="currentPage - 1"
+    [pageSize]="pageSize"
+    [pageSizeOptions]="[50, 100, 200, 500]"
+    (page)="onPageChange($event)">
+  </mat-paginator>
+</div>

--- a/src/app/components/asteroids-list/asteroids-list.component.spec.ts
+++ b/src/app/components/asteroids-list/asteroids-list.component.spec.ts
@@ -4,7 +4,7 @@ import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { of, throwError } from 'rxjs';
 import { AsteroidsListComponent } from './asteroids-list.component';
-import { AsteroidsService, Asteroid } from '../../services/asteroids.service';
+import { AsteroidsService, Asteroid, AsteroidTag } from '../../services/asteroids.service';
 import { TopBarService } from '../../services/top-bar.service';
 
 describe('AsteroidsListComponent', () => {
@@ -12,8 +12,14 @@ describe('AsteroidsListComponent', () => {
   let fixture: ComponentFixture<AsteroidsListComponent>;
   let asteroidsService: {
     listAsteroids: ReturnType<typeof vi.fn>;
+    listTags: ReturnType<typeof vi.fn>;
   };
   let router: Router;
+
+  const mockTags: AsteroidTag[] = [
+    { tag_id: 1, name: 'neo', description: null, color: '#e53935' },
+    { tag_id: 2, name: 'pha', description: null, color: null }
+  ];
 
   const mockAsteroid: Asteroid = {
     asteroid_id: 1,
@@ -28,7 +34,8 @@ describe('AsteroidsListComponent', () => {
     mean_motion: 0.214,
     semimajor_axis: 2.77,
     absolute_magnitude: 3.34,
-    slope_parameter: 0.12
+    slope_parameter: 0.12,
+    tags: [mockTags[0]]
   };
 
   const emptyListResponse = {
@@ -41,7 +48,8 @@ describe('AsteroidsListComponent', () => {
 
   beforeEach(async () => {
     asteroidsService = {
-      listAsteroids: vi.fn().mockReturnValue(of(emptyListResponse))
+      listAsteroids: vi.fn().mockReturnValue(of(emptyListResponse)),
+      listTags: vi.fn().mockReturnValue(of(mockTags))
     };
 
     await TestBed.configureTestingModule({
@@ -67,10 +75,12 @@ describe('AsteroidsListComponent', () => {
     expect(component).toBeTruthy();
   });
 
-  it('should load asteroids on init', () => {
+  it('should load asteroids and available tags on init', () => {
     expect(asteroidsService.listAsteroids).toHaveBeenCalledWith(
       expect.objectContaining({ page: 1, per_page: 100, sort_by: 'number', sort_order: 'asc' })
     );
+    expect(asteroidsService.listTags).toHaveBeenCalled();
+    expect(component.availableTags).toEqual(mockTags);
   });
 
   it('should reject an inverted magnitude range', () => {
@@ -89,10 +99,27 @@ describe('AsteroidsListComponent', () => {
     );
   });
 
+  it('should send tags and tags_mode when tags are selected', () => {
+    component.filterForm.patchValue({ tags: ['neo', 'pha'], tags_mode: 'all' });
+    component.applyFilters();
+    expect(asteroidsService.listAsteroids).toHaveBeenCalledWith(
+      expect.objectContaining({ tags: 'neo,pha', tags_mode: 'all' })
+    );
+  });
+
+  it('should omit tags params when no tags are selected', () => {
+    component.filterForm.patchValue({ tags: [] });
+    component.applyFilters();
+    const lastCall = asteroidsService.listAsteroids.mock.calls.at(-1)[0];
+    expect(lastCall.tags).toBeUndefined();
+    expect(lastCall.tags_mode).toBeUndefined();
+  });
+
   it('should clear filters and reload', () => {
-    component.filterForm.patchValue({ designation: '00001', number: 1 });
+    component.filterForm.patchValue({ designation: '00001', number: 1, tags: ['neo'] });
     component.clearFilters();
     expect(component.filterForm.value.designation).toBeNull();
+    expect(component.filterForm.value.tags).toEqual([]);
     expect(asteroidsService.listAsteroids.mock.calls.length).toBeGreaterThan(1);
   });
 

--- a/src/app/components/asteroids-list/asteroids-list.component.spec.ts
+++ b/src/app/components/asteroids-list/asteroids-list.component.spec.ts
@@ -1,0 +1,110 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { provideRouter, Router } from '@angular/router';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { of, throwError } from 'rxjs';
+import { AsteroidsListComponent } from './asteroids-list.component';
+import { AsteroidsService, Asteroid } from '../../services/asteroids.service';
+import { TopBarService } from '../../services/top-bar.service';
+
+describe('AsteroidsListComponent', () => {
+  let component: AsteroidsListComponent;
+  let fixture: ComponentFixture<AsteroidsListComponent>;
+  let asteroidsService: {
+    listAsteroids: ReturnType<typeof vi.fn>;
+  };
+  let router: Router;
+
+  const mockAsteroid: Asteroid = {
+    asteroid_id: 1,
+    number: 1,
+    designation: '00001',
+    epoch: 'K25A2',
+    mean_anomaly: 10.5,
+    perihelion_arg: 73.6,
+    ascending_node: 80.3,
+    inclination: 10.6,
+    eccentricity: 0.078,
+    mean_motion: 0.214,
+    semimajor_axis: 2.77,
+    absolute_magnitude: 3.34,
+    slope_parameter: 0.12
+  };
+
+  const emptyListResponse = {
+    asteroids: [],
+    total: 0,
+    page: 1,
+    per_page: 100,
+    pages: 0
+  };
+
+  beforeEach(async () => {
+    asteroidsService = {
+      listAsteroids: vi.fn().mockReturnValue(of(emptyListResponse))
+    };
+
+    await TestBed.configureTestingModule({
+      imports: [
+        HttpClientTestingModule,
+        NoopAnimationsModule,
+        AsteroidsListComponent
+      ],
+      providers: [
+        TopBarService,
+        provideRouter([]),
+        { provide: AsteroidsService, useValue: asteroidsService }
+      ]
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(AsteroidsListComponent);
+    component = fixture.componentInstance;
+    router = TestBed.inject(Router);
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('should load asteroids on init', () => {
+    expect(asteroidsService.listAsteroids).toHaveBeenCalledWith(
+      expect.objectContaining({ page: 1, per_page: 100, sort_by: 'number', sort_order: 'asc' })
+    );
+  });
+
+  it('should reject an inverted magnitude range', () => {
+    component.filterForm.patchValue({ mag_min: 10, mag_max: 5 });
+    component.applyFilters();
+    expect(component.filterError).toContain('Minimum magnitude');
+    expect(asteroidsService.listAsteroids).toHaveBeenCalledTimes(1);
+  });
+
+  it('should apply filters when valid', () => {
+    component.filterForm.patchValue({ designation: '00001', numbered: true, mag_min: 1, mag_max: 10 });
+    component.applyFilters();
+    expect(component.filterError).toBeNull();
+    expect(asteroidsService.listAsteroids).toHaveBeenCalledWith(
+      expect.objectContaining({ designation: '00001', numbered: true, mag_min: 1, mag_max: 10 })
+    );
+  });
+
+  it('should clear filters and reload', () => {
+    component.filterForm.patchValue({ designation: '00001', number: 1 });
+    component.clearFilters();
+    expect(component.filterForm.value.designation).toBeNull();
+    expect(asteroidsService.listAsteroids.mock.calls.length).toBeGreaterThan(1);
+  });
+
+  it('should set filter error when list request fails', () => {
+    asteroidsService.listAsteroids.mockReturnValueOnce(throwError(() => new Error('fail')));
+    component.loadAsteroids();
+    expect(component.filterError).toContain('Could not load asteroids');
+  });
+
+  it('should navigate to asteroid detail on row click', () => {
+    const navigateSpy = vi.spyOn(router, 'navigate');
+    component.openAsteroid(mockAsteroid);
+    expect(navigateSpy).toHaveBeenCalledWith(['/asteroids', 1]);
+  });
+});

--- a/src/app/components/asteroids-list/asteroids-list.component.ts
+++ b/src/app/components/asteroids-list/asteroids-list.component.ts
@@ -1,0 +1,246 @@
+import { Component, OnInit, OnDestroy, HostListener, inject } from '@angular/core';
+import { Router } from '@angular/router';
+import { AsteroidsService, Asteroid } from '../../services/asteroids.service';
+import { MatSortModule, Sort } from '@angular/material/sort';
+import { MatPaginatorModule, PageEvent } from '@angular/material/paginator';
+import { Subscription } from 'rxjs';
+import { FormBuilder, FormGroup, ReactiveFormsModule } from '@angular/forms';
+import { trigger, state, style, transition, animate } from '@angular/animations';
+import { TopBarService } from '../../services/top-bar.service';
+import { MatTableModule } from '@angular/material/table';
+import { MatFormFieldModule } from '@angular/material/form-field';
+import { MatInputModule } from '@angular/material/input';
+import { MatButtonModule } from '@angular/material/button';
+import { MatSelectModule } from '@angular/material/select';
+
+interface LoadAsteroidsParams {
+  sort_by?: string;
+  sort_order?: 'asc' | 'desc';
+  designation?: string;
+  number?: number;
+  numbered?: boolean;
+  mag_min?: number;
+  mag_max?: number;
+}
+
+@Component({
+  selector: 'app-asteroids-list',
+  templateUrl: './asteroids-list.component.html',
+  styleUrls: ['./asteroids-list.component.css'],
+  animations: [
+    trigger('filterExpand', [
+      state('collapsed', style({
+        height: '0px',
+        minHeight: '0',
+        padding: '0',
+        opacity: '0'
+      })),
+      state('expanded', style({
+        height: '*',
+        padding: '1rem'
+      })),
+      transition('expanded <=> collapsed', [
+        animate('200ms ease-in-out')
+      ])
+    ])
+  ],
+  imports: [
+    MatTableModule,
+    MatSortModule,
+    MatPaginatorModule,
+    MatFormFieldModule,
+    MatInputModule,
+    MatButtonModule,
+    MatSelectModule,
+    ReactiveFormsModule
+  ]
+})
+export class AsteroidsListComponent implements OnInit, OnDestroy {
+  private asteroidsService = inject(AsteroidsService);
+  private fb = inject(FormBuilder);
+  private topBarService = inject(TopBarService);
+  private router = inject(Router);
+
+  private readonly MOBILE_BREAKPOINT = 640;
+  isMobile = typeof window !== 'undefined' && window.innerWidth <= this.MOBILE_BREAKPOINT;
+
+  @HostListener('window:resize')
+  onResize(): void {
+    this.isMobile = window.innerWidth <= this.MOBILE_BREAKPOINT;
+  }
+
+  get displayedColumns(): string[] {
+    if (this.isMobile) {
+      return ['number', 'designation', 'absolute_magnitude'];
+    }
+    return ['number', 'designation', 'absolute_magnitude', 'semimajor_axis', 'eccentricity', 'inclination'];
+  }
+
+  currentSort: {
+    sort_by: string;
+    sort_order: 'asc' | 'desc';
+  } = {
+    sort_by: 'number',
+    sort_order: 'asc'
+  };
+
+  asteroids: Asteroid[] = [];
+  totalAsteroids = 0;
+  currentPage = 1;
+  pageSize = 100;
+  filterError: string | null = null;
+  private subscriptions: Subscription[] = [];
+  filterForm: FormGroup;
+  isFilterVisible = false;
+
+  constructor() {
+    this.initFilterForm();
+
+    setTimeout(() => {
+      this.topBarService.updateState({
+        showFilter: true,
+        filterVisible: this.isFilterVisible,
+        onFilterToggle: () => this.toggleFilters()
+      });
+    });
+  }
+
+  private initFilterForm() {
+    this.filterForm = this.fb.group({
+      designation: [null as string | null],
+      number: [null as number | null],
+      numbered: [null as boolean | null],
+      mag_min: [null as number | null],
+      mag_max: [null as number | null]
+    });
+  }
+
+  onFilterSubmit(event: Event) {
+    event.preventDefault();
+    this.applyFilters();
+  }
+
+  ngOnInit() {
+    this.loadAsteroids({
+      ...this.getFilterParams(),
+      sort_by: this.currentSort.sort_by,
+      sort_order: this.currentSort.sort_order
+    });
+  }
+
+  private updateTitle() {
+    this.topBarService.updateState({
+      title: `Asteroids: ${this.totalAsteroids.toLocaleString()}`
+    });
+  }
+
+  private getFilterParams(): Partial<LoadAsteroidsParams> {
+    const v = this.filterForm.value;
+    const out: Partial<LoadAsteroidsParams> = {};
+    if (v.designation != null && v.designation !== '') out.designation = String(v.designation).trim();
+    const number = v.number != null && v.number !== '' ? Number(v.number) : null;
+    if (number != null && !Number.isNaN(number)) out.number = number;
+    if (v.numbered === true || v.numbered === false) out.numbered = v.numbered;
+    const magMin = v.mag_min != null && v.mag_min !== '' ? Number(v.mag_min) : null;
+    const magMax = v.mag_max != null && v.mag_max !== '' ? Number(v.mag_max) : null;
+    if (magMin != null && !Number.isNaN(magMin)) out.mag_min = magMin;
+    if (magMax != null && !Number.isNaN(magMax)) out.mag_max = magMax;
+    return out;
+  }
+
+  /** Returns an error message when the magnitude range is inconsistent. */
+  validateFilters(): string | null {
+    const v = this.filterForm.value;
+    const hasMin = v.mag_min != null && v.mag_min !== '';
+    const hasMax = v.mag_max != null && v.mag_max !== '';
+    if (hasMin && hasMax && Number(v.mag_min) > Number(v.mag_max)) {
+      return 'Minimum magnitude must not be greater than maximum magnitude.';
+    }
+    return null;
+  }
+
+  applyFilters() {
+    this.filterError = this.validateFilters();
+    if (this.filterError) return;
+
+    this.currentPage = 1;
+    this.loadAsteroids({
+      ...this.getFilterParams(),
+      sort_by: this.currentSort.sort_by,
+      sort_order: this.currentSort.sort_order
+    });
+  }
+
+  clearFilters() {
+    this.filterError = null;
+    this.filterForm.reset({
+      designation: null,
+      number: null,
+      numbered: null,
+      mag_min: null,
+      mag_max: null
+    });
+    this.currentPage = 1;
+    this.loadAsteroids({
+      sort_by: this.currentSort.sort_by,
+      sort_order: this.currentSort.sort_order
+    });
+  }
+
+  loadAsteroids(params: LoadAsteroidsParams = {}) {
+    this.asteroidsService.listAsteroids({
+      page: this.currentPage,
+      per_page: this.pageSize,
+      ...params
+    }).subscribe({
+      next: response => {
+        this.filterError = null;
+        this.asteroids = response.asteroids;
+        this.totalAsteroids = response.total;
+        this.updateTitle();
+      },
+      error: () => {
+        this.filterError = 'Could not load asteroids. Check your filters and try again.';
+      }
+    });
+  }
+
+  onPageChange(event: PageEvent) {
+    this.currentPage = event.pageIndex + 1;
+    this.pageSize = event.pageSize;
+    this.loadAsteroids({
+      ...this.getFilterParams(),
+      sort_by: this.currentSort.sort_by,
+      sort_order: this.currentSort.sort_order
+    });
+  }
+
+  onSortChange(sort: Sort) {
+    this.currentSort = {
+      sort_by: sort.active,
+      sort_order: (sort.direction as 'asc' | 'desc') || 'asc'
+    };
+
+    this.loadAsteroids({
+      ...this.getFilterParams(),
+      sort_by: this.currentSort.sort_by,
+      sort_order: this.currentSort.sort_order
+    });
+  }
+
+  toggleFilters() {
+    this.isFilterVisible = !this.isFilterVisible;
+    this.topBarService.updateState({
+      filterVisible: this.isFilterVisible
+    });
+  }
+
+  openAsteroid(asteroid: Asteroid): void {
+    this.router.navigate(['/asteroids', asteroid.asteroid_id]);
+  }
+
+  ngOnDestroy() {
+    this.subscriptions.forEach(sub => sub.unsubscribe());
+    this.topBarService.resetState();
+  }
+}

--- a/src/app/components/asteroids-list/asteroids-list.component.ts
+++ b/src/app/components/asteroids-list/asteroids-list.component.ts
@@ -1,8 +1,9 @@
 import { Component, OnInit, OnDestroy, HostListener, inject } from '@angular/core';
 import { Router } from '@angular/router';
-import { AsteroidsService, Asteroid } from '../../services/asteroids.service';
+import { AsteroidsService, Asteroid, AsteroidTag } from '../../services/asteroids.service';
 import { MatSortModule, Sort } from '@angular/material/sort';
 import { MatPaginatorModule, PageEvent } from '@angular/material/paginator';
+import { MatChipsModule } from '@angular/material/chips';
 import { Subscription } from 'rxjs';
 import { FormBuilder, FormGroup, ReactiveFormsModule } from '@angular/forms';
 import { trigger, state, style, transition, animate } from '@angular/animations';
@@ -21,6 +22,8 @@ interface LoadAsteroidsParams {
   numbered?: boolean;
   mag_min?: number;
   mag_max?: number;
+  tags?: string;
+  tags_mode?: 'any' | 'all';
 }
 
 @Component({
@@ -48,6 +51,7 @@ interface LoadAsteroidsParams {
     MatTableModule,
     MatSortModule,
     MatPaginatorModule,
+    MatChipsModule,
     MatFormFieldModule,
     MatInputModule,
     MatButtonModule,
@@ -73,7 +77,7 @@ export class AsteroidsListComponent implements OnInit, OnDestroy {
     if (this.isMobile) {
       return ['number', 'designation', 'absolute_magnitude'];
     }
-    return ['number', 'designation', 'absolute_magnitude', 'semimajor_axis', 'eccentricity', 'inclination'];
+    return ['number', 'designation', 'absolute_magnitude', 'semimajor_axis', 'eccentricity', 'inclination', 'tags'];
   }
 
   currentSort: {
@@ -85,6 +89,7 @@ export class AsteroidsListComponent implements OnInit, OnDestroy {
   };
 
   asteroids: Asteroid[] = [];
+  availableTags: AsteroidTag[] = [];
   totalAsteroids = 0;
   currentPage = 1;
   pageSize = 100;
@@ -111,7 +116,9 @@ export class AsteroidsListComponent implements OnInit, OnDestroy {
       number: [null as number | null],
       numbered: [null as boolean | null],
       mag_min: [null as number | null],
-      mag_max: [null as number | null]
+      mag_max: [null as number | null],
+      tags: [[] as string[]],
+      tags_mode: ['any' as 'any' | 'all']
     });
   }
 
@@ -121,6 +128,13 @@ export class AsteroidsListComponent implements OnInit, OnDestroy {
   }
 
   ngOnInit() {
+    this.subscriptions.push(
+      this.asteroidsService.listTags().subscribe({
+        next: tags => { this.availableTags = tags; },
+        error: () => { this.availableTags = []; }
+      })
+    );
+
     this.loadAsteroids({
       ...this.getFilterParams(),
       sort_by: this.currentSort.sort_by,
@@ -145,6 +159,11 @@ export class AsteroidsListComponent implements OnInit, OnDestroy {
     const magMax = v.mag_max != null && v.mag_max !== '' ? Number(v.mag_max) : null;
     if (magMin != null && !Number.isNaN(magMin)) out.mag_min = magMin;
     if (magMax != null && !Number.isNaN(magMax)) out.mag_max = magMax;
+    const tags: string[] = v.tags ?? [];
+    if (tags.length > 0) {
+      out.tags = tags.join(',');
+      out.tags_mode = v.tags_mode === 'all' ? 'all' : 'any';
+    }
     return out;
   }
 
@@ -178,7 +197,9 @@ export class AsteroidsListComponent implements OnInit, OnDestroy {
       number: null,
       numbered: null,
       mag_min: null,
-      mag_max: null
+      mag_max: null,
+      tags: [],
+      tags_mode: 'any'
     });
     this.currentPage = 1;
     this.loadAsteroids({

--- a/src/app/components/layout/layout.component.html
+++ b/src/app/components/layout/layout.component.html
@@ -50,6 +50,10 @@
       <mat-icon>star</mat-icon>
       <span>Catalogs</span>
     </button>
+    <button mat-menu-item routerLink="/asteroids">
+      <mat-icon>grain</mat-icon>
+      <span>Asteroids</span>
+    </button>
     <button mat-menu-item (click)="openAboutDialog()">
       <mat-icon>info</mat-icon>
       <span>About</span>

--- a/src/app/components/sky-map/sky-map.component.css
+++ b/src/app/components/sky-map/sky-map.component.css
@@ -19,8 +19,8 @@
 
 .scope-chips {
   position: absolute;
-  top: 8px;
-  left: 8px;
+  bottom: 8px;
+  right: 8px;
   z-index: 100;
 }
 

--- a/src/app/services/asteroids.service.spec.ts
+++ b/src/app/services/asteroids.service.spec.ts
@@ -1,12 +1,20 @@
 import { TestBed } from '@angular/core/testing';
 import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
-import { AsteroidsService, Asteroid } from './asteroids.service';
+import { AsteroidsService, Asteroid, AsteroidTag } from './asteroids.service';
 import { LoginService } from './login.service';
 import { Hevelius } from 'src/hevelius';
 
 describe('AsteroidsService', () => {
   let service: AsteroidsService;
   let httpMock: HttpTestingController;
+
+  const mockTag: AsteroidTag = {
+    tag_id: 1,
+    name: 'neo',
+    description: 'Near-Earth object',
+    color: '#e53935',
+    asteroid_count: 1
+  };
 
   const mockAsteroid: Asteroid = {
     asteroid_id: 1,
@@ -21,7 +29,8 @@ describe('AsteroidsService', () => {
     mean_motion: 0.214,
     semimajor_axis: 2.77,
     absolute_magnitude: 3.34,
-    slope_parameter: 0.12
+    slope_parameter: 0.12,
+    tags: [mockTag]
   };
 
   beforeEach(() => {
@@ -81,7 +90,9 @@ describe('AsteroidsService', () => {
         mag_min: 4,
         mag_max: 10,
         sort_by: 'absolute_magnitude',
-        sort_order: 'desc'
+        sort_order: 'desc',
+        tags: 'neo,pha',
+        tags_mode: 'all'
       }).subscribe(response => {
         expect(response.total).toBe(0);
       });
@@ -94,6 +105,8 @@ describe('AsteroidsService', () => {
       expect(req.request.params.get('mag_max')).toBe('10');
       expect(req.request.params.get('sort_by')).toBe('absolute_magnitude');
       expect(req.request.params.get('sort_order')).toBe('desc');
+      expect(req.request.params.get('tags')).toBe('neo,pha');
+      expect(req.request.params.get('tags_mode')).toBe('all');
       req.flush(mockResponse);
     });
 
@@ -122,6 +135,85 @@ describe('AsteroidsService', () => {
       expect(req.request.method).toBe('GET');
       expect(req.request.headers.get('Authorization')).toBe('Bearer test-token');
       req.flush(mockResponse);
+    });
+  });
+
+  describe('listTags', () => {
+    it('should return the tags array', () => {
+      service.listTags().subscribe(tags => {
+        expect(tags).toEqual([mockTag]);
+      });
+
+      const req = httpMock.expectOne(`${Hevelius.apiUrl}/asteroid-tags`);
+      expect(req.request.method).toBe('GET');
+      req.flush({ tags: [mockTag] });
+    });
+  });
+
+  describe('createTag', () => {
+    it('should POST a new tag', () => {
+      const mockResponse = { status: true, tag_id: 1, tag: mockTag, msg: 'Tag created successfully.' };
+
+      service.createTag({ name: 'neo', description: 'Near-Earth object', color: '#e53935' }).subscribe(response => {
+        expect(response).toEqual(mockResponse);
+      });
+
+      const req = httpMock.expectOne(`${Hevelius.apiUrl}/asteroid-tags`);
+      expect(req.request.method).toBe('POST');
+      expect(req.request.body).toEqual({ name: 'neo', description: 'Near-Earth object', color: '#e53935' });
+      req.flush(mockResponse);
+    });
+  });
+
+  describe('updateTag', () => {
+    it('should PATCH the tag', () => {
+      const mockResponse = { status: true, tag: mockTag, msg: 'Tag updated.' };
+
+      service.updateTag(1, { color: '#000000' }).subscribe(response => {
+        expect(response).toEqual(mockResponse);
+      });
+
+      const req = httpMock.expectOne(`${Hevelius.apiUrl}/asteroid-tags/1`);
+      expect(req.request.method).toBe('PATCH');
+      expect(req.request.body).toEqual({ color: '#000000' });
+      req.flush(mockResponse);
+    });
+  });
+
+  describe('deleteTag', () => {
+    it('should DELETE the tag', () => {
+      service.deleteTag(1).subscribe(response => {
+        expect(response.status).toBe(true);
+      });
+
+      const req = httpMock.expectOne(`${Hevelius.apiUrl}/asteroid-tags/1`);
+      expect(req.request.method).toBe('DELETE');
+      req.flush({ status: true, msg: 'Tag deleted' });
+    });
+  });
+
+  describe('attachTag', () => {
+    it('should POST to the asteroid tags endpoint', () => {
+      service.attachTag(5, 1).subscribe(response => {
+        expect(response.status).toBe(true);
+      });
+
+      const req = httpMock.expectOne(`${Hevelius.apiUrl}/asteroids/5/tags`);
+      expect(req.request.method).toBe('POST');
+      expect(req.request.body).toEqual({ tag_id: 1 });
+      req.flush({ status: true, msg: 'Tag added' });
+    });
+  });
+
+  describe('detachTag', () => {
+    it('should DELETE the asteroid/tag pairing', () => {
+      service.detachTag(5, 1).subscribe(response => {
+        expect(response.status).toBe(true);
+      });
+
+      const req = httpMock.expectOne(`${Hevelius.apiUrl}/asteroids/5/tags/1`);
+      expect(req.request.method).toBe('DELETE');
+      req.flush({ status: true, msg: 'Tag removed' });
     });
   });
 });

--- a/src/app/services/asteroids.service.spec.ts
+++ b/src/app/services/asteroids.service.spec.ts
@@ -216,4 +216,52 @@ describe('AsteroidsService', () => {
       req.flush({ status: true, msg: 'Tag removed' });
     });
   });
+
+  describe('getVisibility', () => {
+    it('should GET the visibility curve with scope_id and defaults', () => {
+      const mockResponse = {
+        status: true,
+        scope_id: 1,
+        scope_name: 'Warsaw scope',
+        night_start: '2026-07-19 20:00:00.000',
+        night_end: '2026-07-20 04:00:00.000',
+        samples: [{ time: '2026-07-19 20:00:00.000', altitude_deg: 12.3, azimuth_deg: 45.6, apparent_magnitude: 8.8 }],
+        max_altitude_deg: 40.1,
+        max_altitude_time: '2026-07-20 00:00:00.000',
+        apparent_magnitude_at_max: 8.5,
+        visible: true,
+        has_magnitude_estimate: true,
+        msg: 'OK'
+      };
+
+      service.getVisibility(1, { scopeId: 1 }).subscribe(response => {
+        expect(response).toEqual(mockResponse);
+      });
+
+      const req = httpMock.expectOne(`${Hevelius.apiUrl}/asteroids/1/visibility?scope_id=1`);
+      expect(req.request.method).toBe('GET');
+      req.flush(mockResponse);
+    });
+
+    it('should pass an explicit date and step_minutes', () => {
+      const mockResponse = {
+        status: true, scope_id: 2, scope_name: 'Scope 2',
+        night_start: '2026-01-15 18:00:00.000', night_end: '2026-01-16 06:00:00.000',
+        samples: [], max_altitude_deg: -5, max_altitude_time: '2026-01-15 22:00:00.000',
+        apparent_magnitude_at_max: null, visible: false, has_magnitude_estimate: false
+      };
+
+      service.getVisibility(1, { scopeId: 2, date: '2026-01-15', stepMinutes: 30 }).subscribe(response => {
+        expect(response.visible).toBe(false);
+      });
+
+      const req = httpMock.expectOne(
+        (r) => r.url === `${Hevelius.apiUrl}/asteroids/1/visibility`
+      );
+      expect(req.request.params.get('scope_id')).toBe('2');
+      expect(req.request.params.get('date')).toBe('2026-01-15');
+      expect(req.request.params.get('step_minutes')).toBe('30');
+      req.flush(mockResponse);
+    });
+  });
 });

--- a/src/app/services/asteroids.service.spec.ts
+++ b/src/app/services/asteroids.service.spec.ts
@@ -1,0 +1,127 @@
+import { TestBed } from '@angular/core/testing';
+import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
+import { AsteroidsService, Asteroid } from './asteroids.service';
+import { LoginService } from './login.service';
+import { Hevelius } from 'src/hevelius';
+
+describe('AsteroidsService', () => {
+  let service: AsteroidsService;
+  let httpMock: HttpTestingController;
+
+  const mockAsteroid: Asteroid = {
+    asteroid_id: 1,
+    number: 1,
+    designation: '00001',
+    epoch: 'K25A2',
+    mean_anomaly: 10.5,
+    perihelion_arg: 73.6,
+    ascending_node: 80.3,
+    inclination: 10.6,
+    eccentricity: 0.078,
+    mean_motion: 0.214,
+    semimajor_axis: 2.77,
+    absolute_magnitude: 3.34,
+    slope_parameter: 0.12
+  };
+
+  beforeEach(() => {
+    const loginServiceSpy = {
+      getAuthHeaders: vi.fn().mockReturnValue({ 'Authorization': 'Bearer test-token' }),
+    };
+
+    TestBed.configureTestingModule({
+      imports: [HttpClientTestingModule],
+      providers: [
+        AsteroidsService,
+        { provide: LoginService, useValue: loginServiceSpy }
+      ]
+    });
+
+    service = TestBed.inject(AsteroidsService);
+    httpMock = TestBed.inject(HttpTestingController);
+  });
+
+  afterEach(() => {
+    httpMock.verify();
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+
+  describe('listAsteroids', () => {
+    it('should return paginated asteroids', () => {
+      const mockResponse = {
+        asteroids: [mockAsteroid],
+        total: 1,
+        page: 1,
+        per_page: 100,
+        pages: 1
+      };
+
+      service.listAsteroids({ page: 1, per_page: 100 }).subscribe(response => {
+        expect(response).toEqual(mockResponse);
+        expect(response.asteroids.length).toBe(1);
+        expect(response.total).toBe(1);
+      });
+
+      const req = httpMock.expectOne(`${Hevelius.apiUrl}/asteroids?page=1&per_page=100`);
+      expect(req.request.method).toBe('GET');
+      expect(req.request.headers.get('Authorization')).toBe('Bearer test-token');
+      req.flush(mockResponse);
+    });
+
+    it('should pass filter, sort, and paging params', () => {
+      const mockResponse = { asteroids: [], total: 0, page: 1, per_page: 100, pages: 0 };
+
+      service.listAsteroids({
+        designation: '00001',
+        number: 1,
+        numbered: true,
+        mag_min: 4,
+        mag_max: 10,
+        sort_by: 'absolute_magnitude',
+        sort_order: 'desc'
+      }).subscribe(response => {
+        expect(response.total).toBe(0);
+      });
+
+      const req = httpMock.expectOne((r) => r.url === `${Hevelius.apiUrl}/asteroids`);
+      expect(req.request.params.get('designation')).toBe('00001');
+      expect(req.request.params.get('number')).toBe('1');
+      expect(req.request.params.get('numbered')).toBe('true');
+      expect(req.request.params.get('mag_min')).toBe('4');
+      expect(req.request.params.get('mag_max')).toBe('10');
+      expect(req.request.params.get('sort_by')).toBe('absolute_magnitude');
+      expect(req.request.params.get('sort_order')).toBe('desc');
+      req.flush(mockResponse);
+    });
+
+    it('should handle empty parameters', () => {
+      const mockResponse = { asteroids: [], total: 0, page: 1, per_page: 100, pages: 0 };
+
+      service.listAsteroids().subscribe(response => {
+        expect(response).toEqual(mockResponse);
+      });
+
+      const req = httpMock.expectOne(`${Hevelius.apiUrl}/asteroids`);
+      req.flush(mockResponse);
+    });
+  });
+
+  describe('getAsteroid', () => {
+    it('should return a single asteroid', () => {
+      const mockResponse = { status: true, asteroid: mockAsteroid, msg: 'OK' };
+
+      service.getAsteroid(1).subscribe(response => {
+        expect(response).toEqual(mockResponse);
+        expect(response.asteroid.designation).toBe('00001');
+      });
+
+      const req = httpMock.expectOne(`${Hevelius.apiUrl}/asteroids/1`);
+      expect(req.request.method).toBe('GET');
+      expect(req.request.headers.get('Authorization')).toBe('Bearer test-token');
+      req.flush(mockResponse);
+    });
+  });
+});

--- a/src/app/services/asteroids.service.ts
+++ b/src/app/services/asteroids.service.ts
@@ -1,0 +1,88 @@
+import { Injectable, inject } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { LoginService } from './login.service';
+import { Observable } from 'rxjs';
+import { Hevelius } from 'src/hevelius';
+
+export interface Asteroid {
+  asteroid_id: number;
+  number: number | null;
+  designation: string;
+  epoch: string;
+  mean_anomaly: number;
+  perihelion_arg: number;
+  ascending_node: number;
+  inclination: number;
+  eccentricity: number;
+  mean_motion: number;
+  semimajor_axis: number;
+  absolute_magnitude: number | null;
+  slope_parameter: number | null;
+}
+
+export interface AsteroidsListResponse {
+  asteroids: Asteroid[];
+  total: number;
+  page: number;
+  per_page: number;
+  pages: number;
+}
+
+export interface AsteroidDetailResponse {
+  status: boolean;
+  asteroid: Asteroid;
+  msg?: string;
+}
+
+export interface ListAsteroidsParams {
+  page?: number;
+  per_page?: number;
+  sort_by?: string;
+  sort_order?: string;
+  designation?: string;
+  number?: number;
+  numbered?: boolean;
+  mag_min?: number;
+  mag_max?: number;
+}
+
+@Injectable({
+  providedIn: 'root'
+})
+export class AsteroidsService {
+  private http = inject(HttpClient);
+  private loginService = inject(LoginService);
+
+  private baseUrl = Hevelius.apiUrl + '/asteroids';
+
+  /** GET /api/asteroids — paginated asteroids with sorting and filtering. */
+  listAsteroids(params: ListAsteroidsParams = {}): Observable<AsteroidsListResponse> {
+    return this.http.get<AsteroidsListResponse>(
+      this.baseUrl,
+      {
+        params: this.sanitizeParams(params),
+        headers: this.loginService.getAuthHeaders()
+      }
+    );
+  }
+
+  /** GET /api/asteroids/{id} — single asteroid's full orbital element set. */
+  getAsteroid(asteroidId: number): Observable<AsteroidDetailResponse> {
+    return this.http.get<AsteroidDetailResponse>(
+      `${this.baseUrl}/${asteroidId}`,
+      { headers: this.loginService.getAuthHeaders() }
+    );
+  }
+
+  /* eslint-disable  @typescript-eslint/no-explicit-any */
+  private sanitizeParams(params: any): { [key: string]: string } {
+    const sanitized: { [key: string]: string } = {};
+    Object.keys(params).forEach(key => {
+      const value = params[key];
+      if (value !== undefined && value !== null && value !== '') {
+        sanitized[key] = String(value);
+      }
+    });
+    return sanitized;
+  }
+}

--- a/src/app/services/asteroids.service.ts
+++ b/src/app/services/asteroids.service.ts
@@ -2,7 +2,16 @@ import { Injectable, inject } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
 import { LoginService } from './login.service';
 import { Observable } from 'rxjs';
+import { map } from 'rxjs/operators';
 import { Hevelius } from 'src/hevelius';
+
+export interface AsteroidTag {
+  tag_id: number;
+  name: string;
+  description: string | null;
+  color: string | null;
+  asteroid_count?: number;
+}
 
 export interface Asteroid {
   asteroid_id: number;
@@ -18,6 +27,7 @@ export interface Asteroid {
   semimajor_axis: number;
   absolute_magnitude: number | null;
   slope_parameter: number | null;
+  tags: AsteroidTag[];
 }
 
 export interface AsteroidsListResponse {
@@ -44,6 +54,41 @@ export interface ListAsteroidsParams {
   numbered?: boolean;
   mag_min?: number;
   mag_max?: number;
+  /** Comma-separated tag names to filter by (e.g. "neo,pha"). */
+  tags?: string;
+  /** 'any' (default): at least one listed tag. 'all': every listed tag. */
+  tags_mode?: 'any' | 'all';
+}
+
+export interface AsteroidTagsListResponse {
+  tags: AsteroidTag[];
+}
+
+export interface AsteroidTagResponse {
+  status: boolean;
+  tag: AsteroidTag;
+  msg?: string;
+}
+
+export interface AsteroidTagCreateResponse extends AsteroidTagResponse {
+  tag_id: number;
+}
+
+export interface AsteroidTagCreateParams {
+  name: string;
+  description?: string | null;
+  color?: string | null;
+}
+
+export interface AsteroidTagUpdateParams {
+  name?: string;
+  description?: string | null;
+  color?: string | null;
+}
+
+export interface StatusMsgResponse {
+  status: boolean;
+  msg?: string;
 }
 
 @Injectable({
@@ -54,6 +99,7 @@ export class AsteroidsService {
   private loginService = inject(LoginService);
 
   private baseUrl = Hevelius.apiUrl + '/asteroids';
+  private tagsUrl = Hevelius.apiUrl + '/asteroid-tags';
 
   /** GET /api/asteroids — paginated asteroids with sorting and filtering. */
   listAsteroids(params: ListAsteroidsParams = {}): Observable<AsteroidsListResponse> {
@@ -70,6 +116,59 @@ export class AsteroidsService {
   getAsteroid(asteroidId: number): Observable<AsteroidDetailResponse> {
     return this.http.get<AsteroidDetailResponse>(
       `${this.baseUrl}/${asteroidId}`,
+      { headers: this.loginService.getAuthHeaders() }
+    );
+  }
+
+  /** GET /api/asteroid-tags — all tags with per-tag asteroid counts. */
+  listTags(): Observable<AsteroidTag[]> {
+    return this.http.get<AsteroidTagsListResponse>(
+      this.tagsUrl,
+      { headers: this.loginService.getAuthHeaders() }
+    ).pipe(
+      map(response => response.tags ?? [])
+    );
+  }
+
+  /** POST /api/asteroid-tags — create a new tag definition. */
+  createTag(params: AsteroidTagCreateParams): Observable<AsteroidTagCreateResponse> {
+    return this.http.post<AsteroidTagCreateResponse>(
+      this.tagsUrl,
+      params,
+      { headers: this.loginService.getAuthHeaders() }
+    );
+  }
+
+  /** PATCH /api/asteroid-tags/{id} — edit a tag's name, description, or color. */
+  updateTag(tagId: number, params: AsteroidTagUpdateParams): Observable<AsteroidTagResponse> {
+    return this.http.patch<AsteroidTagResponse>(
+      `${this.tagsUrl}/${tagId}`,
+      params,
+      { headers: this.loginService.getAuthHeaders() }
+    );
+  }
+
+  /** DELETE /api/asteroid-tags/{id} — delete a tag definition entirely. */
+  deleteTag(tagId: number): Observable<StatusMsgResponse> {
+    return this.http.delete<StatusMsgResponse>(
+      `${this.tagsUrl}/${tagId}`,
+      { headers: this.loginService.getAuthHeaders() }
+    );
+  }
+
+  /** POST /api/asteroids/{id}/tags — attach an existing tag to an asteroid. */
+  attachTag(asteroidId: number, tagId: number): Observable<StatusMsgResponse> {
+    return this.http.post<StatusMsgResponse>(
+      `${this.baseUrl}/${asteroidId}/tags`,
+      { tag_id: tagId },
+      { headers: this.loginService.getAuthHeaders() }
+    );
+  }
+
+  /** DELETE /api/asteroids/{id}/tags/{tagId} — detach a tag from an asteroid. */
+  detachTag(asteroidId: number, tagId: number): Observable<StatusMsgResponse> {
+    return this.http.delete<StatusMsgResponse>(
+      `${this.baseUrl}/${asteroidId}/tags/${tagId}`,
       { headers: this.loginService.getAuthHeaders() }
     );
   }

--- a/src/app/services/asteroids.service.ts
+++ b/src/app/services/asteroids.service.ts
@@ -91,6 +91,35 @@ export interface StatusMsgResponse {
   msg?: string;
 }
 
+export interface AsteroidVisibilitySample {
+  time: string;
+  altitude_deg: number;
+  azimuth_deg: number;
+  apparent_magnitude: number | null;
+}
+
+export interface AsteroidVisibilityResponse {
+  status: boolean;
+  scope_id: number;
+  scope_name: string;
+  night_start: string;
+  night_end: string;
+  samples: AsteroidVisibilitySample[];
+  max_altitude_deg: number;
+  max_altitude_time: string;
+  apparent_magnitude_at_max: number | null;
+  visible: boolean;
+  has_magnitude_estimate: boolean;
+  msg?: string;
+}
+
+export interface AsteroidVisibilityParams {
+  scopeId: number;
+  /** Evening date (YYYY-MM-DD) whose night to compute; defaults to tonight. */
+  date?: string;
+  stepMinutes?: number;
+}
+
 @Injectable({
   providedIn: 'root'
 })
@@ -170,6 +199,24 @@ export class AsteroidsService {
     return this.http.delete<StatusMsgResponse>(
       `${this.baseUrl}/${asteroidId}/tags/${tagId}`,
       { headers: this.loginService.getAuthHeaders() }
+    );
+  }
+
+  /**
+   * GET /api/asteroids/{id}/visibility — altitude/azimuth/magnitude curve for
+   * one night from a telescope's location. Defaults to tonight.
+   */
+  getVisibility(asteroidId: number, params: AsteroidVisibilityParams): Observable<AsteroidVisibilityResponse> {
+    return this.http.get<AsteroidVisibilityResponse>(
+      `${this.baseUrl}/${asteroidId}/visibility`,
+      {
+        params: this.sanitizeParams({
+          scope_id: params.scopeId,
+          date: params.date,
+          step_minutes: params.stepMinutes
+        }),
+        headers: this.loginService.getAuthHeaders()
+      }
     );
   }
 


### PR DESCRIPTION
## Summary
- Adds an **Asteroids** page (`/asteroids`) backed by the new `hevelius-backend` `/api/asteroids` endpoints (see borowka-obs/hevelius-backend#98), mirroring the existing Objects page: paged, sortable table with a collapsible filter panel (designation, MPC number, numbered vs. unnumbered/provisional, absolute magnitude range) and a mobile card layout.
- Adds an asteroid detail page (`/asteroids/:id`) showing the full orbital element set (epoch, H, G, a, e, i, Ω, ω, M, n) for a selected asteroid; reached by clicking a row in the list.
- Wires both routes into `app-routing.module.ts` and adds an **Asteroids** entry to the nav menu.

Closes #147.

## Test plan
- [x] `npm run lint` — passes
- [x] `npm test` — all 31 spec files / 159 tests pass, including new specs for `AsteroidsService`, `AsteroidsListComponent`, and `AsteroidDetailComponent`
- [x] `npm run build` — production build succeeds
- [x] Manual verification: ran the backend locally against a seeded Postgres DB, logged in via a JWT, and exercised the UI in a headless browser — list renders real data with correct columns, pagination, and unnumbered (`—`) handling; designation filter narrows results correctly; column-header sort re-orders rows; row click navigates to the detail page and renders all orbital elements correctly.


---
_Generated by [Claude Code](https://claude.ai/code/session_01QvQ7KmmwvS29AVbhRH6BF4)_