### PR TITLE
Self-service profile edit, password change, and forgot-password

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 0.6.0 (unreleased)
 
+- Added self-service account management: the **User** page (`/user`) now
+  lets you edit your own first name, last name, phone, e-mail, and AAVSO
+  observer ID, and change your password (current + new password).
+- Added a **forgot password** flow: "Forgot your password?" on the login
+  page leads to `/forgot-password` (enter your username or e-mail; the
+  backend always replies with the same generic message so the page can't be
+  used to enumerate accounts) and `/reset-password?token=...` (set a new
+  password from the link's one-time token).
 - Asteroid detail page reorganized into three widgets: grouped orbital
   elements (identification / orbital elements / photometric), tags, and a
   new **Visibility** widget — pick an active telescope (its location drives

--- a/src/app/app-routing.module.ts
+++ b/src/app/app-routing.module.ts
@@ -1,5 +1,7 @@
 import { Routes } from '@angular/router';
 import { LoginComponent } from './login/login.component';
+import { ForgotPasswordComponent } from './forgot-password/forgot-password.component';
+import { ResetPasswordComponent } from './reset-password/reset-password.component';
 import { LayoutComponent } from './components/layout/layout.component';
 import { TasksComponent } from './components/tasks/tasks.component';
 import { NightPlanComponent } from './components/night-plan/night-plan.component';
@@ -19,6 +21,8 @@ import { AuthGuard } from './guards/auth.guard';
 
 export const routes: Routes = [
   { path: 'login', component: LoginComponent },
+  { path: 'forgot-password', component: ForgotPasswordComponent },
+  { path: 'reset-password', component: ResetPasswordComponent },
   {
     path: '',
     component: LayoutComponent,

--- a/src/app/components/tasks/tasks.component.spec.ts
+++ b/src/app/components/tasks/tasks.component.spec.ts
@@ -2,7 +2,6 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { TasksComponent } from './tasks.component';
 import { MatTableModule } from '@angular/material/table';
 import { MatDialogModule } from '@angular/material/dialog';
-import { MatSnackBarModule } from '@angular/material/snack-bar';
 import { provideHttpClient } from '@angular/common/http';
 import { provideHttpClientTesting } from '@angular/common/http/testing';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
@@ -16,7 +15,6 @@ describe('TasksComponent', () => {
       imports: [
         MatTableModule,
         MatDialogModule,
-        MatSnackBarModule,
         NoopAnimationsModule,
         TasksComponent
       ],

--- a/src/app/components/tasks/tasks.component.ts
+++ b/src/app/components/tasks/tasks.component.ts
@@ -20,7 +20,6 @@ import { MatInputModule } from '@angular/material/input';
 import { MatButtonModule } from '@angular/material/button';
 import { MatIconModule } from '@angular/material/icon';
 import { MatDialogModule } from '@angular/material/dialog';
-import { MatSnackBarModule } from '@angular/material/snack-bar';
 import { MatTooltipModule } from '@angular/material/tooltip';
 import { RouterModule } from '@angular/router';
 
@@ -60,7 +59,6 @@ import { TaskParams } from '../../models/task-response';
     MatButtonModule,
     MatIconModule,
     MatDialogModule,
-    MatSnackBarModule,
     MatSelectModule,
     MatTooltipModule,
     RouterModule,

--- a/src/app/components/user/user.component.css
+++ b/src/app/components/user/user.component.css
@@ -1,6 +1,6 @@
 .user-card {
   max-width: 640px;
-  margin: 0 auto;
+  margin: 0 auto 16px;
   padding: 16px;
 }
 
@@ -19,4 +19,41 @@
 
 .user-details p {
   margin: 8px 0;
+}
+
+.form-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 0 16px;
+}
+
+.full-width {
+  width: 100%;
+}
+
+.form-actions {
+  grid-column: 1 / -1;
+  display: flex;
+  justify-content: flex-end;
+  margin-top: 8px;
+}
+
+@media (max-width: 640px) {
+  .user-card {
+    max-width: 100%;
+    margin: 0 0 16px;
+    border-radius: 0;
+  }
+
+  .form-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .form-actions {
+    justify-content: stretch;
+  }
+
+  .form-actions button {
+    width: 100%;
+  }
 }

--- a/src/app/components/user/user.component.css
+++ b/src/app/components/user/user.component.css
@@ -21,6 +21,45 @@
   margin: 8px 0;
 }
 
+.detail-list {
+  display: flex;
+  flex-direction: column;
+}
+
+.detail-row {
+  display: flex;
+  align-items: center;
+  min-height: 56px;
+  gap: 8px;
+  border-bottom: 1px solid rgba(0, 0, 0, 0.08);
+}
+
+.detail-row:last-child {
+  border-bottom: none;
+}
+
+.detail-label {
+  flex: 0 0 130px;
+  color: rgba(0, 0, 0, 0.6);
+  font-size: 0.9em;
+}
+
+.detail-value {
+  flex: 1 1 auto;
+  overflow-wrap: anywhere;
+}
+
+.detail-input {
+  flex: 1 1 auto;
+  /* Match the row's height instead of the form field's own bottom hint spacing. */
+  margin-top: 16px;
+}
+
+.edit-btn {
+  flex: 0 0 auto;
+  margin-left: auto;
+}
+
 .form-grid {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
@@ -31,10 +70,15 @@
   width: 100%;
 }
 
+.password-form {
+  padding-top: 8px;
+}
+
 .form-actions {
   grid-column: 1 / -1;
   display: flex;
   justify-content: flex-end;
+  gap: 8px;
   margin-top: 8px;
 }
 
@@ -43,6 +87,11 @@
     max-width: 100%;
     margin: 0 0 16px;
     border-radius: 0;
+  }
+
+  .detail-label {
+    flex-basis: 90px;
+    font-size: 0.85em;
   }
 
   .form-grid {

--- a/src/app/components/user/user.component.html
+++ b/src/app/components/user/user.component.html
@@ -15,83 +15,169 @@
 </mat-card>
 
 <mat-card class="user-card">
-  <h3>Edit profile</h3>
-  <form [formGroup]="profileForm" (ngSubmit)="saveProfile()" class="form-grid">
-    <mat-form-field appearance="outline" class="full-width">
-      <mat-label>First name</mat-label>
-      <input matInput formControlName="firstname" maxlength="32">
-    </mat-form-field>
+  <h3>Profile</h3>
+  <div [formGroup]="profileForm" class="detail-list">
 
-    <mat-form-field appearance="outline" class="full-width">
-      <mat-label>Last name</mat-label>
-      <input matInput formControlName="lastname" maxlength="32">
-    </mat-form-field>
-
-    <mat-form-field appearance="outline" class="full-width">
-      <mat-label>Phone</mat-label>
-      <input matInput formControlName="phone" maxlength="32" type="tel">
-    </mat-form-field>
-
-    <mat-form-field appearance="outline" class="full-width">
-      <mat-label>Email</mat-label>
-      <input matInput formControlName="email" maxlength="64" type="email">
-    </mat-form-field>
-
-    <mat-form-field appearance="outline" class="full-width">
-      <mat-label>AAVSO observer ID</mat-label>
-      <input matInput formControlName="aavso_id" maxlength="5">
-      @if (profileForm.get('aavso_id')?.hasError('maxlength')) {
-        <mat-error>AAVSO ID is at most 5 characters.</mat-error>
+    <div class="detail-row">
+      <div class="detail-label">First name</div>
+      @if (editingField === 'firstname') {
+        <mat-form-field appearance="outline" class="detail-input">
+          <input matInput formControlName="firstname" maxlength="32" (keyup.enter)="saveField('firstname')">
+        </mat-form-field>
+        <button mat-icon-button color="primary" (click)="saveField('firstname')" [disabled]="savingField" aria-label="Save first name">
+          <mat-icon>check</mat-icon>
+        </button>
+        <button mat-icon-button (click)="cancelEdit('firstname')" aria-label="Cancel">
+          <mat-icon>close</mat-icon>
+        </button>
+      } @else {
+        <div class="detail-value">{{ fieldValue('firstname') || '—' }}</div>
+        <button mat-icon-button class="edit-btn" (click)="startEdit('firstname')" aria-label="Edit first name">
+          <mat-icon>edit</mat-icon>
+        </button>
       }
-    </mat-form-field>
-
-    <div class="form-actions">
-      <button mat-raised-button color="primary" type="submit" [disabled]="savingProfile">
-        {{ savingProfile ? 'Saving…' : 'Save changes' }}
-      </button>
     </div>
-  </form>
+
+    <div class="detail-row">
+      <div class="detail-label">Last name</div>
+      @if (editingField === 'lastname') {
+        <mat-form-field appearance="outline" class="detail-input">
+          <input matInput formControlName="lastname" maxlength="32" (keyup.enter)="saveField('lastname')">
+        </mat-form-field>
+        <button mat-icon-button color="primary" (click)="saveField('lastname')" [disabled]="savingField" aria-label="Save last name">
+          <mat-icon>check</mat-icon>
+        </button>
+        <button mat-icon-button (click)="cancelEdit('lastname')" aria-label="Cancel">
+          <mat-icon>close</mat-icon>
+        </button>
+      } @else {
+        <div class="detail-value">{{ fieldValue('lastname') || '—' }}</div>
+        <button mat-icon-button class="edit-btn" (click)="startEdit('lastname')" aria-label="Edit last name">
+          <mat-icon>edit</mat-icon>
+        </button>
+      }
+    </div>
+
+    <div class="detail-row">
+      <div class="detail-label">Phone</div>
+      @if (editingField === 'phone') {
+        <mat-form-field appearance="outline" class="detail-input">
+          <input matInput formControlName="phone" maxlength="32" type="tel" (keyup.enter)="saveField('phone')">
+        </mat-form-field>
+        <button mat-icon-button color="primary" (click)="saveField('phone')" [disabled]="savingField" aria-label="Save phone">
+          <mat-icon>check</mat-icon>
+        </button>
+        <button mat-icon-button (click)="cancelEdit('phone')" aria-label="Cancel">
+          <mat-icon>close</mat-icon>
+        </button>
+      } @else {
+        <div class="detail-value">{{ fieldValue('phone') || '—' }}</div>
+        <button mat-icon-button class="edit-btn" (click)="startEdit('phone')" aria-label="Edit phone">
+          <mat-icon>edit</mat-icon>
+        </button>
+      }
+    </div>
+
+    <div class="detail-row">
+      <div class="detail-label">Email</div>
+      @if (editingField === 'email') {
+        <mat-form-field appearance="outline" class="detail-input">
+          <input matInput formControlName="email" maxlength="64" type="email" (keyup.enter)="saveField('email')">
+        </mat-form-field>
+        <button mat-icon-button color="primary" (click)="saveField('email')" [disabled]="savingField" aria-label="Save email">
+          <mat-icon>check</mat-icon>
+        </button>
+        <button mat-icon-button (click)="cancelEdit('email')" aria-label="Cancel">
+          <mat-icon>close</mat-icon>
+        </button>
+      } @else {
+        <div class="detail-value">{{ fieldValue('email') || '—' }}</div>
+        <button mat-icon-button class="edit-btn" (click)="startEdit('email')" aria-label="Edit email">
+          <mat-icon>edit</mat-icon>
+        </button>
+      }
+    </div>
+
+    <div class="detail-row">
+      <div class="detail-label">AAVSO observer ID</div>
+      @if (editingField === 'aavso_id') {
+        <mat-form-field appearance="outline" class="detail-input">
+          <input matInput formControlName="aavso_id" maxlength="5" (keyup.enter)="saveField('aavso_id')">
+          @if (profileForm.get('aavso_id')?.hasError('maxlength')) {
+            <mat-error>At most 5 characters.</mat-error>
+          }
+        </mat-form-field>
+        <button mat-icon-button color="primary" (click)="saveField('aavso_id')" [disabled]="savingField" aria-label="Save AAVSO observer ID">
+          <mat-icon>check</mat-icon>
+        </button>
+        <button mat-icon-button (click)="cancelEdit('aavso_id')" aria-label="Cancel">
+          <mat-icon>close</mat-icon>
+        </button>
+      } @else {
+        <div class="detail-value">{{ fieldValue('aavso_id') || '—' }}</div>
+        <button mat-icon-button class="edit-btn" (click)="startEdit('aavso_id')" aria-label="Edit AAVSO observer ID">
+          <mat-icon>edit</mat-icon>
+        </button>
+      }
+    </div>
+
+  </div>
 </mat-card>
 
 <mat-card class="user-card">
-  <h3>Change password</h3>
-  <form [formGroup]="passwordForm" (ngSubmit)="changePassword()" class="form-grid">
-    <mat-form-field appearance="outline" class="full-width">
-      <mat-label>Current password</mat-label>
-      <input matInput [type]="hideCurrentPassword ? 'password' : 'text'" formControlName="current_password" autocomplete="current-password">
-      <button mat-icon-button matSuffix type="button" (click)="hideCurrentPassword = !hideCurrentPassword"
-              [attr.aria-label]="'Hide password'" [attr.aria-pressed]="hideCurrentPassword">
-        <mat-icon>{{ hideCurrentPassword ? 'visibility_off' : 'visibility' }}</mat-icon>
-      </button>
-      @if (passwordForm.get('current_password')?.touched && passwordForm.get('current_password')?.hasError('required')) {
-        <mat-error>Current password is required.</mat-error>
+  <h3>Security</h3>
+  <div class="detail-list">
+    <div class="detail-row">
+      <div class="detail-label">Password</div>
+      @if (!showPasswordForm) {
+        <div class="detail-value">••••••••</div>
+        <button mat-icon-button class="edit-btn" (click)="togglePasswordForm()" aria-label="Change password">
+          <mat-icon>edit</mat-icon>
+        </button>
       }
-    </mat-form-field>
-
-    <mat-form-field appearance="outline" class="full-width">
-      <mat-label>New password</mat-label>
-      <input matInput [type]="hideNewPassword ? 'password' : 'text'" formControlName="new_password" autocomplete="new-password">
-      <button mat-icon-button matSuffix type="button" (click)="hideNewPassword = !hideNewPassword"
-              [attr.aria-label]="'Hide password'" [attr.aria-pressed]="hideNewPassword">
-        <mat-icon>{{ hideNewPassword ? 'visibility_off' : 'visibility' }}</mat-icon>
-      </button>
-      @if (passwordForm.get('new_password')?.touched && passwordForm.get('new_password')?.hasError('minlength')) {
-        <mat-error>Password must be at least 8 characters.</mat-error>
-      }
-    </mat-form-field>
-
-    <mat-form-field appearance="outline" class="full-width">
-      <mat-label>Confirm new password</mat-label>
-      <input matInput [type]="hideNewPassword ? 'password' : 'text'" formControlName="confirm_password" autocomplete="new-password">
-      @if (passwordForm.hasError('passwordMismatch') && passwordForm.get('confirm_password')?.touched) {
-        <mat-error>Passwords do not match.</mat-error>
-      }
-    </mat-form-field>
-
-    <div class="form-actions">
-      <button mat-raised-button color="primary" type="submit" [disabled]="changingPassword">
-        {{ changingPassword ? 'Changing…' : 'Change password' }}
-      </button>
     </div>
-  </form>
+
+    @if (showPasswordForm) {
+      <form [formGroup]="passwordForm" (ngSubmit)="changePassword()" class="form-grid password-form">
+        <mat-form-field appearance="outline" class="full-width">
+          <mat-label>Current password</mat-label>
+          <input matInput [type]="hideCurrentPassword ? 'password' : 'text'" formControlName="current_password" autocomplete="current-password">
+          <button mat-icon-button matSuffix type="button" (click)="hideCurrentPassword = !hideCurrentPassword"
+                  [attr.aria-label]="'Hide password'" [attr.aria-pressed]="hideCurrentPassword">
+            <mat-icon>{{ hideCurrentPassword ? 'visibility_off' : 'visibility' }}</mat-icon>
+          </button>
+          @if (passwordForm.get('current_password')?.touched && passwordForm.get('current_password')?.hasError('required')) {
+            <mat-error>Current password is required.</mat-error>
+          }
+        </mat-form-field>
+
+        <mat-form-field appearance="outline" class="full-width">
+          <mat-label>New password</mat-label>
+          <input matInput [type]="hideNewPassword ? 'password' : 'text'" formControlName="new_password" autocomplete="new-password">
+          <button mat-icon-button matSuffix type="button" (click)="hideNewPassword = !hideNewPassword"
+                  [attr.aria-label]="'Hide password'" [attr.aria-pressed]="hideNewPassword">
+            <mat-icon>{{ hideNewPassword ? 'visibility_off' : 'visibility' }}</mat-icon>
+          </button>
+          @if (passwordForm.get('new_password')?.touched && passwordForm.get('new_password')?.hasError('minlength')) {
+            <mat-error>Password must be at least 8 characters.</mat-error>
+          }
+        </mat-form-field>
+
+        <mat-form-field appearance="outline" class="full-width">
+          <mat-label>Confirm new password</mat-label>
+          <input matInput [type]="hideNewPassword ? 'password' : 'text'" formControlName="confirm_password" autocomplete="new-password">
+          @if (passwordForm.hasError('passwordMismatch') && passwordForm.get('confirm_password')?.touched) {
+            <mat-error>Passwords do not match.</mat-error>
+          }
+        </mat-form-field>
+
+        <div class="form-actions">
+          <button mat-button type="button" (click)="togglePasswordForm()">Cancel</button>
+          <button mat-raised-button color="primary" type="submit" [disabled]="changingPassword">
+            {{ changingPassword ? 'Changing…' : 'Change password' }}
+          </button>
+        </div>
+      </form>
+    }
+  </div>
 </mat-card>

--- a/src/app/components/user/user.component.html
+++ b/src/app/components/user/user.component.html
@@ -2,15 +2,96 @@
   <div class="user-header">
     <img [src]="avatarUrl" alt="User avatar" class="avatar-large">
     <div>
-      <h2>{{ user?.firstname }} {{ user?.lastname }}</h2>
-      <p>{{ user?.email || 'No e-mail on profile' }}</p>
+      <h2>{{ profile?.firstname || user?.firstname }} {{ profile?.lastname || user?.lastname }}</h2>
+      <p>{{ profile?.login || user?.login }}</p>
     </div>
   </div>
 
   <div class="user-details">
-    <p><strong>User ID:</strong> {{ user?.user_id }}</p>
-    <p><strong>AAVSO ID:</strong> {{ user?.aavso_id || '-' }}</p>
-    <p><strong>Phone:</strong> {{ user?.phone || '-' }}</p>
-    <p><strong>Permissions:</strong> {{ user?.permissions || '-' }}</p>
+    <p><strong>User ID:</strong> {{ profile?.user_id || user?.user_id }}</p>
+    <p><strong>Permissions:</strong> {{ profile?.permissions ?? user?.permissions ?? '-' }}</p>
+    <p><strong>Login enabled:</strong> {{ profile?.login_enabled ? 'Yes' : 'No' }}</p>
   </div>
+</mat-card>
+
+<mat-card class="user-card">
+  <h3>Edit profile</h3>
+  <form [formGroup]="profileForm" (ngSubmit)="saveProfile()" class="form-grid">
+    <mat-form-field appearance="outline" class="full-width">
+      <mat-label>First name</mat-label>
+      <input matInput formControlName="firstname" maxlength="32">
+    </mat-form-field>
+
+    <mat-form-field appearance="outline" class="full-width">
+      <mat-label>Last name</mat-label>
+      <input matInput formControlName="lastname" maxlength="32">
+    </mat-form-field>
+
+    <mat-form-field appearance="outline" class="full-width">
+      <mat-label>Phone</mat-label>
+      <input matInput formControlName="phone" maxlength="32" type="tel">
+    </mat-form-field>
+
+    <mat-form-field appearance="outline" class="full-width">
+      <mat-label>Email</mat-label>
+      <input matInput formControlName="email" maxlength="64" type="email">
+    </mat-form-field>
+
+    <mat-form-field appearance="outline" class="full-width">
+      <mat-label>AAVSO observer ID</mat-label>
+      <input matInput formControlName="aavso_id" maxlength="5">
+      @if (profileForm.get('aavso_id')?.hasError('maxlength')) {
+        <mat-error>AAVSO ID is at most 5 characters.</mat-error>
+      }
+    </mat-form-field>
+
+    <div class="form-actions">
+      <button mat-raised-button color="primary" type="submit" [disabled]="savingProfile">
+        {{ savingProfile ? 'Saving…' : 'Save changes' }}
+      </button>
+    </div>
+  </form>
+</mat-card>
+
+<mat-card class="user-card">
+  <h3>Change password</h3>
+  <form [formGroup]="passwordForm" (ngSubmit)="changePassword()" class="form-grid">
+    <mat-form-field appearance="outline" class="full-width">
+      <mat-label>Current password</mat-label>
+      <input matInput [type]="hideCurrentPassword ? 'password' : 'text'" formControlName="current_password" autocomplete="current-password">
+      <button mat-icon-button matSuffix type="button" (click)="hideCurrentPassword = !hideCurrentPassword"
+              [attr.aria-label]="'Hide password'" [attr.aria-pressed]="hideCurrentPassword">
+        <mat-icon>{{ hideCurrentPassword ? 'visibility_off' : 'visibility' }}</mat-icon>
+      </button>
+      @if (passwordForm.get('current_password')?.touched && passwordForm.get('current_password')?.hasError('required')) {
+        <mat-error>Current password is required.</mat-error>
+      }
+    </mat-form-field>
+
+    <mat-form-field appearance="outline" class="full-width">
+      <mat-label>New password</mat-label>
+      <input matInput [type]="hideNewPassword ? 'password' : 'text'" formControlName="new_password" autocomplete="new-password">
+      <button mat-icon-button matSuffix type="button" (click)="hideNewPassword = !hideNewPassword"
+              [attr.aria-label]="'Hide password'" [attr.aria-pressed]="hideNewPassword">
+        <mat-icon>{{ hideNewPassword ? 'visibility_off' : 'visibility' }}</mat-icon>
+      </button>
+      @if (passwordForm.get('new_password')?.touched && passwordForm.get('new_password')?.hasError('minlength')) {
+        <mat-error>Password must be at least 8 characters.</mat-error>
+      }
+    </mat-form-field>
+
+    <mat-form-field appearance="outline" class="full-width">
+      <mat-label>Confirm new password</mat-label>
+      <input matInput [type]="hideNewPassword ? 'password' : 'text'" formControlName="confirm_password" autocomplete="new-password">
+      @if (passwordForm.hasError('passwordMismatch') && passwordForm.get('confirm_password')?.touched) {
+        <mat-error>Passwords do not match.</mat-error>
+      }
+    </mat-form-field>
+
+    <div class="form-actions">
+      <button mat-raised-button color="primary" type="submit" [disabled]="changingPassword">
+        {{ changingPassword ? 'Changing…' : 'Change password' }}
+      </button>
+    </div>
+  </form>
 </mat-card>

--- a/src/app/components/user/user.component.spec.ts
+++ b/src/app/components/user/user.component.spec.ts
@@ -65,37 +65,81 @@ describe('UserComponent', () => {
     expect(component).toBeTruthy();
   });
 
-  it('loads the profile and populates the edit form', () => {
+  it('loads the profile and shows it read-only, with no field in edit mode', () => {
     fixture.detectChanges();
     expect(userService.getProfile).toHaveBeenCalled();
-    expect(component.profileForm.value.firstname).toBe('Ada');
-    expect(component.profileForm.value.phone).toBe('555-0100');
-    expect(component.profileForm.value.aavso_id).toBe('AA001');
+    expect(component.editingField).toBeNull();
+    expect(component.fieldValue('firstname')).toBe('Ada');
+    expect(component.fieldValue('phone')).toBe('555-0100');
+    expect(component.fieldValue('aavso_id')).toBe('AA001');
   });
 
-  it('saveProfile updates the profile and syncs the cached login data', async () => {
+  it('startEdit switches a single field into edit mode', () => {
     fixture.detectChanges();
-    component.profileForm.patchValue({ phone: '555-9999' });
-    component.saveProfile();
+    component.startEdit('phone');
+    expect(component.editingField).toBe('phone');
+    expect(component.profileForm.get('phone')?.value).toBe('555-0100');
+  });
+
+  it('cancelEdit discards changes and exits edit mode', () => {
+    fixture.detectChanges();
+    component.startEdit('phone');
+    component.profileForm.get('phone')?.setValue('555-9999');
+    component.cancelEdit('phone');
+
+    expect(component.editingField).toBeNull();
+    expect(component.profileForm.get('phone')?.value).toBe('555-0100');
+    expect(userService.updateProfile).not.toHaveBeenCalled();
+  });
+
+  it('saveField updates only the edited field and syncs the cached login data', async () => {
+    fixture.detectChanges();
+    component.startEdit('phone');
+    component.profileForm.get('phone')?.setValue('555-9999');
+    component.saveField('phone');
     await fixture.whenStable();
 
-    expect(userService.updateProfile).toHaveBeenCalledWith(
-      expect.objectContaining({ firstname: 'Ada', phone: '555-9999' })
-    );
+    expect(userService.updateProfile).toHaveBeenCalledWith({ phone: '555-9999' });
     expect(loginService.loggedIn).toHaveBeenCalled();
-    expect(snackBar.open).toHaveBeenCalledWith('Profile updated.', 'Close', expect.anything());
+    expect(component.editingField).toBeNull();
+    expect(snackBar.open).toHaveBeenCalledWith('Phone updated.', 'Close', expect.anything());
   });
 
-  it('saveProfile surfaces backend error messages', async () => {
+  it('saveField surfaces backend error messages and stays in edit mode', async () => {
     userService.updateProfile.mockReturnValue(
       throwError(() => new HttpErrorResponse({ status: 400, error: { msg: 'Bad request' } }))
     );
     fixture.detectChanges();
-    component.saveProfile();
+    component.startEdit('phone');
+    component.saveField('phone');
     await fixture.whenStable();
 
     expect(snackBar.open).toHaveBeenCalledWith('Bad request', 'Close', expect.anything());
-    expect(component.savingProfile).toBe(false);
+    expect(component.savingField).toBe(false);
+    expect(component.editingField).toBe('phone');
+  });
+
+  it('saveField rejects an invalid value without calling the API', () => {
+    fixture.detectChanges();
+    component.startEdit('aavso_id');
+    component.profileForm.get('aavso_id')?.setValue('TOOLONG');
+    component.saveField('aavso_id');
+
+    expect(userService.updateProfile).not.toHaveBeenCalled();
+    expect(component.editingField).toBe('aavso_id');
+  });
+
+  it('the password form is collapsed by default and toggles open/closed', () => {
+    fixture.detectChanges();
+    expect(component.showPasswordForm).toBe(false);
+
+    component.togglePasswordForm();
+    expect(component.showPasswordForm).toBe(true);
+
+    component.passwordForm.patchValue({ current_password: 'old-pw' });
+    component.togglePasswordForm();
+    expect(component.showPasswordForm).toBe(false);
+    expect(component.passwordForm.value.current_password).toBeFalsy();
   });
 
   it('changePassword rejects mismatched passwords before calling the API', async () => {
@@ -112,8 +156,9 @@ describe('UserComponent', () => {
     expect(userService.changePassword).not.toHaveBeenCalled();
   });
 
-  it('changePassword calls the API and resets the form on success', async () => {
+  it('changePassword calls the API and collapses the form on success', async () => {
     fixture.detectChanges();
+    component.togglePasswordForm();
     component.passwordForm.patchValue({
       current_password: 'old-pw',
       new_password: 'new-password-123',
@@ -129,5 +174,6 @@ describe('UserComponent', () => {
     });
     expect(snackBar.open).toHaveBeenCalledWith('Password changed.', 'Close', expect.anything());
     expect(component.passwordForm.value.current_password).toBeFalsy();
+    expect(component.showPasswordForm).toBe(false);
   });
 });

--- a/src/app/components/user/user.component.spec.ts
+++ b/src/app/components/user/user.component.spec.ts
@@ -1,0 +1,133 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+import { of, throwError } from 'rxjs';
+import { HttpErrorResponse } from '@angular/common/http';
+import { UserComponent } from './user.component';
+import { LoginService } from '../../services/login.service';
+import { UserService, UserProfile } from '../../services/user.service';
+import { GravatarService } from '../../services/gravatar.service';
+import { TopBarService } from '../../services/top-bar.service';
+import { MatSnackBar } from '@angular/material/snack-bar';
+
+describe('UserComponent', () => {
+  let component: UserComponent;
+  let fixture: ComponentFixture<UserComponent>;
+  let userService: {
+    getProfile: ReturnType<typeof vi.fn>;
+    updateProfile: ReturnType<typeof vi.fn>;
+    changePassword: ReturnType<typeof vi.fn>;
+  };
+  let loginService: { getUser: ReturnType<typeof vi.fn>; loggedIn: ReturnType<typeof vi.fn> };
+  let snackBar: { open: ReturnType<typeof vi.fn> };
+
+  const profile: UserProfile = {
+    user_id: 1,
+    login: 'user1',
+    firstname: 'Ada',
+    lastname: 'Lovelace',
+    share: 0,
+    phone: '555-0100',
+    email: 'ada@example.com',
+    permissions: 0,
+    aavso_id: 'AA001',
+    login_enabled: true
+  };
+
+  beforeEach(async () => {
+    userService = {
+      getProfile: vi.fn().mockReturnValue(of(profile)),
+      updateProfile: vi.fn().mockReturnValue(of(profile)),
+      changePassword: vi.fn().mockReturnValue(of({ status: true, msg: 'Password updated' }))
+    };
+    loginService = {
+      getUser: vi.fn().mockReturnValue({ user_id: 1, firstname: 'Ada', email: 'ada@example.com', permissions: 0 }),
+      loggedIn: vi.fn()
+    };
+    snackBar = { open: vi.fn() };
+
+    await TestBed.configureTestingModule({
+      imports: [NoopAnimationsModule, UserComponent],
+      providers: [
+        { provide: UserService, useValue: userService },
+        { provide: LoginService, useValue: loginService },
+        { provide: MatSnackBar, useValue: snackBar },
+        GravatarService,
+        TopBarService
+      ]
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(UserComponent);
+    component = fixture.componentInstance;
+  });
+
+  it('should create', () => {
+    fixture.detectChanges();
+    expect(component).toBeTruthy();
+  });
+
+  it('loads the profile and populates the edit form', () => {
+    fixture.detectChanges();
+    expect(userService.getProfile).toHaveBeenCalled();
+    expect(component.profileForm.value.firstname).toBe('Ada');
+    expect(component.profileForm.value.phone).toBe('555-0100');
+    expect(component.profileForm.value.aavso_id).toBe('AA001');
+  });
+
+  it('saveProfile updates the profile and syncs the cached login data', async () => {
+    fixture.detectChanges();
+    component.profileForm.patchValue({ phone: '555-9999' });
+    component.saveProfile();
+    await fixture.whenStable();
+
+    expect(userService.updateProfile).toHaveBeenCalledWith(
+      expect.objectContaining({ firstname: 'Ada', phone: '555-9999' })
+    );
+    expect(loginService.loggedIn).toHaveBeenCalled();
+    expect(snackBar.open).toHaveBeenCalledWith('Profile updated.', 'Close', expect.anything());
+  });
+
+  it('saveProfile surfaces backend error messages', async () => {
+    userService.updateProfile.mockReturnValue(
+      throwError(() => new HttpErrorResponse({ status: 400, error: { msg: 'Bad request' } }))
+    );
+    fixture.detectChanges();
+    component.saveProfile();
+    await fixture.whenStable();
+
+    expect(snackBar.open).toHaveBeenCalledWith('Bad request', 'Close', expect.anything());
+    expect(component.savingProfile).toBe(false);
+  });
+
+  it('changePassword rejects mismatched passwords before calling the API', async () => {
+    fixture.detectChanges();
+    component.passwordForm.patchValue({
+      current_password: 'old-pw',
+      new_password: 'new-password-123',
+      confirm_password: 'different-password'
+    });
+    expect(component.passwordForm.hasError('passwordMismatch')).toBe(true);
+
+    component.changePassword();
+    await fixture.whenStable();
+    expect(userService.changePassword).not.toHaveBeenCalled();
+  });
+
+  it('changePassword calls the API and resets the form on success', async () => {
+    fixture.detectChanges();
+    component.passwordForm.patchValue({
+      current_password: 'old-pw',
+      new_password: 'new-password-123',
+      confirm_password: 'new-password-123'
+    });
+
+    component.changePassword();
+    await fixture.whenStable();
+
+    expect(userService.changePassword).toHaveBeenCalledWith({
+      current_password: 'old-pw',
+      new_password: 'new-password-123'
+    });
+    expect(snackBar.open).toHaveBeenCalledWith('Password changed.', 'Close', expect.anything());
+    expect(component.passwordForm.value.current_password).toBeFalsy();
+  });
+});

--- a/src/app/components/user/user.component.ts
+++ b/src/app/components/user/user.component.ts
@@ -22,6 +22,16 @@ import { GravatarService } from '../../services/gravatar.service';
 import { TopBarService } from '../../services/top-bar.service';
 import { User } from '../../models/user';
 
+type ProfileField = 'firstname' | 'lastname' | 'phone' | 'email' | 'aavso_id';
+
+const PROFILE_FIELD_LABELS: Record<ProfileField, string> = {
+  firstname: 'First name',
+  lastname: 'Last name',
+  phone: 'Phone',
+  email: 'Email',
+  aavso_id: 'AAVSO observer ID'
+};
+
 /** Requires the confirm_password field to equal new_password. */
 function passwordsMatchValidator(group: AbstractControl): ValidationErrors | null {
   const newPassword = group.get('new_password')?.value;
@@ -52,10 +62,18 @@ export class UserComponent implements OnInit {
     private formBuilder = inject(FormBuilder);
     private snackBar = inject(MatSnackBar);
 
+    readonly profileFields: ProfileField[] = ['firstname', 'lastname', 'phone', 'email', 'aavso_id'];
+    readonly fieldLabels = PROFILE_FIELD_LABELS;
+
     user: User | null = null;
     profile: UserProfile | null = null;
     avatarUrl = '';
-    savingProfile = false;
+
+    /** Field currently switched into edit mode, or null when the panel just shows details. */
+    editingField: ProfileField | null = null;
+    savingField = false;
+
+    showPasswordForm = false;
     changingPassword = false;
     hideCurrentPassword = true;
     hideNewPassword = true;
@@ -87,7 +105,7 @@ export class UserComponent implements OnInit {
 
         this.user = this.loginService.getUser();
         this.updateAvatar(this.user?.email, this.user?.user_id);
-        // Pre-fill from the cached login response so the form isn't empty while
+        // Pre-fill from the cached login response so the panel isn't empty while
         // /users/me loads (or if it's unreachable).
         this.profileForm.patchValue({
             firstname: this.user?.firstname ?? '',
@@ -122,29 +140,40 @@ export class UserComponent implements OnInit {
         this.avatarUrl = this.gravatarService.getAvatarUrl(email, fallbackId, 96);
     }
 
-    saveProfile(): void {
-        if (this.profileForm.invalid) {
-            this.profileForm.markAllAsTouched();
+    fieldValue(field: ProfileField): string {
+        return (this.profile?.[field] ?? this.user?.[field] ?? '') as string;
+    }
+
+    startEdit(field: ProfileField): void {
+        this.profileForm.get(field)?.setValue(this.fieldValue(field));
+        this.editingField = field;
+    }
+
+    cancelEdit(field: ProfileField): void {
+        this.profileForm.get(field)?.setValue(this.fieldValue(field));
+        this.profileForm.get(field)?.markAsUntouched();
+        this.editingField = null;
+    }
+
+    saveField(field: ProfileField): void {
+        const control = this.profileForm.get(field);
+        if (!control || control.invalid) {
+            control?.markAsTouched();
             return;
         }
-        this.savingProfile = true;
-        const v = this.profileForm.getRawValue();
-        const body: UserProfileUpdate = {
-            firstname: v.firstname?.trim() || null,
-            lastname: v.lastname?.trim() || null,
-            phone: v.phone?.trim() || null,
-            email: v.email?.trim() || null,
-            aavso_id: v.aavso_id?.trim() || null
-        };
+        this.savingField = true;
+        const raw = (control.value as string | null)?.trim() ?? '';
+        const body: UserProfileUpdate = { [field]: raw || null };
         this.userService.updateProfile(body).pipe(first()).subscribe({
             next: profile => {
-                this.savingProfile = false;
+                this.savingField = false;
                 this.applyProfile(profile);
                 this.mergeIntoStoredUser(profile);
-                this.showMessage('Profile updated.');
+                this.editingField = null;
+                this.showMessage(`${this.fieldLabels[field]} updated.`);
             },
             error: (err: HttpErrorResponse) => {
-                this.savingProfile = false;
+                this.savingField = false;
                 this.showMessage(err?.error?.msg || 'Failed to update profile.');
             }
         });
@@ -167,6 +196,13 @@ export class UserComponent implements OnInit {
         });
     }
 
+    togglePasswordForm(): void {
+        this.showPasswordForm = !this.showPasswordForm;
+        if (!this.showPasswordForm) {
+            this.passwordForm.reset();
+        }
+    }
+
     changePassword(): void {
         if (this.passwordForm.invalid) {
             this.passwordForm.markAllAsTouched();
@@ -181,6 +217,7 @@ export class UserComponent implements OnInit {
                 next: () => {
                     this.changingPassword = false;
                     this.passwordForm.reset();
+                    this.showPasswordForm = false;
                     this.showMessage('Password changed.');
                 },
                 error: (err: HttpErrorResponse) => {

--- a/src/app/components/user/user.component.ts
+++ b/src/app/components/user/user.component.ts
@@ -1,25 +1,81 @@
 import { Component, OnInit, inject } from '@angular/core';
 import { CommonModule } from '@angular/common';
+import { HttpErrorResponse } from '@angular/common/http';
+import {
+  AbstractControl,
+  FormBuilder,
+  FormGroup,
+  ReactiveFormsModule,
+  ValidationErrors,
+  Validators
+} from '@angular/forms';
 import { MatCardModule } from '@angular/material/card';
+import { MatFormFieldModule } from '@angular/material/form-field';
+import { MatInputModule } from '@angular/material/input';
+import { MatButtonModule } from '@angular/material/button';
+import { MatIconModule } from '@angular/material/icon';
+import { MatSnackBar } from '@angular/material/snack-bar';
+import { first } from 'rxjs/operators';
 import { LoginService } from '../../services/login.service';
+import { UserService, UserProfile, UserProfileUpdate } from '../../services/user.service';
 import { GravatarService } from '../../services/gravatar.service';
 import { TopBarService } from '../../services/top-bar.service';
 import { User } from '../../models/user';
 
+/** Requires the confirm_password field to equal new_password. */
+function passwordsMatchValidator(group: AbstractControl): ValidationErrors | null {
+  const newPassword = group.get('new_password')?.value;
+  const confirm = group.get('confirm_password')?.value;
+  return newPassword && confirm && newPassword !== confirm ? { passwordMismatch: true } : null;
+}
+
 @Component({
     selector: 'app-user',
     standalone: true,
-    imports: [CommonModule, MatCardModule],
+    imports: [
+        CommonModule,
+        ReactiveFormsModule,
+        MatCardModule,
+        MatFormFieldModule,
+        MatInputModule,
+        MatButtonModule,
+        MatIconModule
+    ],
     templateUrl: './user.component.html',
     styleUrls: ['./user.component.css']
 })
 export class UserComponent implements OnInit {
     private loginService = inject(LoginService);
+    private userService = inject(UserService);
     private gravatarService = inject(GravatarService);
     private topBarService = inject(TopBarService);
+    private formBuilder = inject(FormBuilder);
+    private snackBar = inject(MatSnackBar);
 
     user: User | null = null;
+    profile: UserProfile | null = null;
     avatarUrl = '';
+    savingProfile = false;
+    changingPassword = false;
+    hideCurrentPassword = true;
+    hideNewPassword = true;
+
+    profileForm: FormGroup = this.formBuilder.group({
+        firstname: [''],
+        lastname: [''],
+        phone: [''],
+        email: [''],
+        aavso_id: ['', Validators.maxLength(5)]
+    });
+
+    passwordForm: FormGroup = this.formBuilder.group(
+        {
+            current_password: ['', Validators.required],
+            new_password: ['', [Validators.required, Validators.minLength(8)]],
+            confirm_password: ['', Validators.required]
+        },
+        { validators: passwordsMatchValidator }
+    );
 
     ngOnInit(): void {
         this.topBarService.updateState({
@@ -30,7 +86,115 @@ export class UserComponent implements OnInit {
         });
 
         this.user = this.loginService.getUser();
-        const fallbackId = this.user?.user_id?.toString() ?? this.user?.firstname ?? 'hevelius-user';
-        this.avatarUrl = this.gravatarService.getAvatarUrl(this.user?.email, fallbackId, 96);
+        this.updateAvatar(this.user?.email, this.user?.user_id);
+        // Pre-fill from the cached login response so the form isn't empty while
+        // /users/me loads (or if it's unreachable).
+        this.profileForm.patchValue({
+            firstname: this.user?.firstname ?? '',
+            lastname: this.user?.lastname ?? '',
+            phone: this.user?.phone ?? '',
+            email: this.user?.email ?? '',
+            aavso_id: this.user?.aavso_id ?? ''
+        });
+
+        this.userService.getProfile().pipe(first()).subscribe({
+            next: profile => this.applyProfile(profile),
+            error: () => {
+                // Keep showing the cached login response; /users/me is unreachable.
+            }
+        });
+    }
+
+    private applyProfile(profile: UserProfile): void {
+        this.profile = profile;
+        this.profileForm.patchValue({
+            firstname: profile.firstname ?? '',
+            lastname: profile.lastname ?? '',
+            phone: profile.phone ?? '',
+            email: profile.email ?? '',
+            aavso_id: profile.aavso_id ?? ''
+        });
+        this.updateAvatar(profile.email, profile.user_id);
+    }
+
+    private updateAvatar(email: string | null | undefined, userId: number | undefined | null): void {
+        const fallbackId = userId?.toString() ?? this.user?.firstname ?? 'hevelius-user';
+        this.avatarUrl = this.gravatarService.getAvatarUrl(email, fallbackId, 96);
+    }
+
+    saveProfile(): void {
+        if (this.profileForm.invalid) {
+            this.profileForm.markAllAsTouched();
+            return;
+        }
+        this.savingProfile = true;
+        const v = this.profileForm.getRawValue();
+        const body: UserProfileUpdate = {
+            firstname: v.firstname?.trim() || null,
+            lastname: v.lastname?.trim() || null,
+            phone: v.phone?.trim() || null,
+            email: v.email?.trim() || null,
+            aavso_id: v.aavso_id?.trim() || null
+        };
+        this.userService.updateProfile(body).pipe(first()).subscribe({
+            next: profile => {
+                this.savingProfile = false;
+                this.applyProfile(profile);
+                this.mergeIntoStoredUser(profile);
+                this.showMessage('Profile updated.');
+            },
+            error: (err: HttpErrorResponse) => {
+                this.savingProfile = false;
+                this.showMessage(err?.error?.msg || 'Failed to update profile.');
+            }
+        });
+    }
+
+    // Keep the locally cached login data (used elsewhere, e.g. the top bar avatar) in sync.
+    private mergeIntoStoredUser(profile: UserProfile): void {
+        const stored = this.loginService.getUser();
+        if (!stored) {
+            return;
+        }
+        this.loginService.loggedIn({
+            ...(stored as unknown as Record<string, unknown>),
+            firstname: profile.firstname ?? undefined,
+            lastname: profile.lastname ?? undefined,
+            phone: profile.phone ?? undefined,
+            email: profile.email ?? undefined,
+            aavso_id: profile.aavso_id ?? undefined,
+            permissions: stored.permissions != null ? String(stored.permissions) : undefined
+        });
+    }
+
+    changePassword(): void {
+        if (this.passwordForm.invalid) {
+            this.passwordForm.markAllAsTouched();
+            return;
+        }
+        this.changingPassword = true;
+        const v = this.passwordForm.getRawValue();
+        this.userService
+            .changePassword({ current_password: v.current_password, new_password: v.new_password })
+            .pipe(first())
+            .subscribe({
+                next: () => {
+                    this.changingPassword = false;
+                    this.passwordForm.reset();
+                    this.showMessage('Password changed.');
+                },
+                error: (err: HttpErrorResponse) => {
+                    this.changingPassword = false;
+                    this.showMessage(err?.error?.msg || 'Failed to change password.');
+                }
+            });
+    }
+
+    showMessage(text: string): void {
+        this.snackBar.open(text, 'Close', {
+            duration: 4000,
+            horizontalPosition: 'center',
+            verticalPosition: 'bottom'
+        });
     }
 }

--- a/src/app/forgot-password/forgot-password.component.css
+++ b/src/app/forgot-password/forgot-password.component.css
@@ -1,0 +1,37 @@
+.auth-card {
+  max-width: 360px;
+  margin: 40px auto;
+}
+
+.auth-form {
+  display: flex;
+  flex-direction: column;
+}
+
+.full-width {
+  width: 100%;
+}
+
+.back-link {
+  text-align: center;
+  margin-top: 8px;
+}
+
+.link-button {
+  background: none;
+  border: none;
+  padding: 0;
+  color: #3f51b5;
+  text-decoration: underline;
+  cursor: pointer;
+  font-size: inherit;
+}
+
+@media (max-width: 640px) {
+  .auth-card {
+    max-width: 100%;
+    margin: 0;
+    border-radius: 0;
+    box-shadow: none;
+  }
+}

--- a/src/app/forgot-password/forgot-password.component.html
+++ b/src/app/forgot-password/forgot-password.component.html
@@ -1,0 +1,29 @@
+<mat-toolbar color="primary">
+  <mat-toolbar-row>
+    <span>{{ title }}</span>
+  </mat-toolbar-row>
+</mat-toolbar>
+
+<mat-card class="auth-card">
+  <mat-card-content>
+    @if (!submitted) {
+      <form [formGroup]="form" (ngSubmit)="onSubmit()" class="auth-form">
+        <p>Enter your username or e-mail address and we'll send you a link to reset your password.</p>
+        <mat-form-field appearance="outline" class="full-width">
+          <mat-label>Username or e-mail</mat-label>
+          <input matInput formControlName="login_or_email">
+        </mat-form-field>
+
+        <button mat-raised-button color="primary" type="submit">
+          Send reset link
+        </button>
+      </form>
+    } @else {
+      <p>If that account exists, a password reset e-mail has been sent. Please check your inbox.</p>
+    }
+
+    <p class="back-link">
+      <button type="button" class="link-button" (click)="goToLogin()">Back to login</button>
+    </p>
+  </mat-card-content>
+</mat-card>

--- a/src/app/forgot-password/forgot-password.component.spec.ts
+++ b/src/app/forgot-password/forgot-password.component.spec.ts
@@ -1,0 +1,74 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+import { HttpErrorResponse } from '@angular/common/http';
+import { Router } from '@angular/router';
+import { of, throwError } from 'rxjs';
+import { ForgotPasswordComponent } from './forgot-password.component';
+import { LoginService } from '../services/login.service';
+import { MatSnackBar } from '@angular/material/snack-bar';
+
+describe('ForgotPasswordComponent', () => {
+  let component: ForgotPasswordComponent;
+  let fixture: ComponentFixture<ForgotPasswordComponent>;
+  let loginService: { forgotPassword: ReturnType<typeof vi.fn> };
+  let snackBar: { open: ReturnType<typeof vi.fn> };
+  let router: { navigateByUrl: ReturnType<typeof vi.fn> };
+
+  beforeEach(async () => {
+    loginService = { forgotPassword: vi.fn() };
+    snackBar = { open: vi.fn() };
+    router = { navigateByUrl: vi.fn() };
+
+    await TestBed.configureTestingModule({
+      imports: [NoopAnimationsModule, ForgotPasswordComponent],
+      providers: [
+        { provide: LoginService, useValue: loginService },
+        { provide: MatSnackBar, useValue: snackBar },
+        { provide: Router, useValue: router }
+      ]
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(ForgotPasswordComponent);
+    component = fixture.componentInstance;
+  });
+
+  it('should create', () => {
+    fixture.detectChanges();
+    expect(component).toBeTruthy();
+  });
+
+  it('does not submit an empty form', () => {
+    fixture.detectChanges();
+    component.onSubmit();
+    expect(loginService.forgotPassword).not.toHaveBeenCalled();
+  });
+
+  it('submits the login/email and shows the generic confirmation', async () => {
+    loginService.forgotPassword.mockReturnValue(
+      of({ status: true, msg: 'If that account exists, a password reset email has been sent.' })
+    );
+    fixture.detectChanges();
+    component.form.patchValue({ login_or_email: 'user1' });
+    component.onSubmit();
+    await fixture.whenStable();
+
+    expect(loginService.forgotPassword).toHaveBeenCalledWith('user1');
+    expect(component.submitted).toBe(true);
+    expect(snackBar.open).toHaveBeenCalled();
+  });
+
+  it('shows an error message when the backend is unreachable', async () => {
+    loginService.forgotPassword.mockReturnValue(throwError(() => new HttpErrorResponse({ status: 0 })));
+    fixture.detectChanges();
+    component.form.patchValue({ login_or_email: 'user1' });
+    component.onSubmit();
+    await fixture.whenStable();
+
+    expect(component.submitted).toBe(false);
+    expect(snackBar.open).toHaveBeenCalledWith(
+      'Backend is unresponsive. Please check the server.',
+      'Close',
+      expect.anything()
+    );
+  });
+});

--- a/src/app/forgot-password/forgot-password.component.ts
+++ b/src/app/forgot-password/forgot-password.component.ts
@@ -1,0 +1,86 @@
+import { Component, OnInit, inject } from '@angular/core';
+import { UntypedFormGroup, Validators, UntypedFormBuilder, ReactiveFormsModule } from '@angular/forms';
+import { Router } from '@angular/router';
+import { first } from 'rxjs/operators';
+import { LoginService, StatusMsgResponse } from '../services/login.service';
+import { Hevelius } from '../../hevelius';
+import { MatSnackBar } from '@angular/material/snack-bar';
+import { HttpErrorResponse } from '@angular/common/http';
+import { MatButtonModule } from '@angular/material/button';
+import { MatFormFieldModule } from '@angular/material/form-field';
+import { MatInputModule } from '@angular/material/input';
+import { MatToolbarModule } from '@angular/material/toolbar';
+import { MatCardModule } from '@angular/material/card';
+
+@Component({
+    selector: 'app-forgot-password',
+    templateUrl: './forgot-password.component.html',
+    styleUrls: ['./forgot-password.component.css'],
+    standalone: true,
+    imports: [
+        ReactiveFormsModule,
+        MatFormFieldModule,
+        MatInputModule,
+        MatButtonModule,
+        MatToolbarModule,
+        MatCardModule
+    ]
+})
+export class ForgotPasswordComponent implements OnInit {
+    private loginService = inject(LoginService);
+    private router = inject(Router);
+    private snackBar = inject(MatSnackBar);
+    private formBuilder = inject(UntypedFormBuilder);
+
+    title: string;
+    submitted = false;
+    form: UntypedFormGroup;
+
+    constructor() {
+        this.title = Hevelius.title;
+    }
+
+    ngOnInit(): void {
+        this.form = this.formBuilder.group({
+            login_or_email: ['', Validators.required]
+        });
+    }
+
+    onSubmit(): void {
+        if (this.form.invalid) {
+            this.showMessage('Please enter your username or e-mail.');
+            return;
+        }
+
+        this.loginService
+            .forgotPassword(this.form.controls.login_or_email.value)
+            .pipe(first())
+            .subscribe({
+                next: (data: StatusMsgResponse) => {
+                    // The backend always returns a generic message, whether or not the
+                    // account exists, so this can't be used to enumerate accounts.
+                    this.submitted = true;
+                    this.showMessage(data.msg || 'If that account exists, a password reset email has been sent.');
+                },
+                error: (error: HttpErrorResponse) => {
+                    if (error.status === 0) {
+                        this.showMessage('Backend is unresponsive. Please check the server.');
+                    } else {
+                        this.showMessage(`Request failed with error code: ${error.status}`);
+                    }
+                }
+            });
+    }
+
+    goToLogin(): void {
+        this.router.navigateByUrl('/login');
+    }
+
+    showMessage(text: string): void {
+        this.snackBar.open(text, 'Close', {
+            duration: 5000,
+            horizontalPosition: 'center',
+            verticalPosition: 'bottom'
+        });
+    }
+}

--- a/src/app/login/login.component.css
+++ b/src/app/login/login.component.css
@@ -18,6 +18,17 @@
     text-align: center;
 }
 
+.forgot-password-link {
+    margin-top: 12px;
+    font-size: 0.9em;
+    background: none;
+    border: none;
+    padding: 0;
+    color: #3f51b5;
+    text-decoration: underline;
+    cursor: pointer;
+}
+
 img {
     display: block;
     margin-left: auto;

--- a/src/app/login/login.component.html
+++ b/src/app/login/login.component.html
@@ -25,6 +25,7 @@
     <button mat-raised-button color="primary" type="submit">
         Login
     </button>
+    <button type="button" class="forgot-password-link" (click)="goToForgotPassword()">Forgot your password?</button>
 </form>
     </mat-card-content>
 </mat-card>

--- a/src/app/login/login.component.ts
+++ b/src/app/login/login.component.ts
@@ -4,7 +4,7 @@ import { Router } from '@angular/router';
 import { first } from 'rxjs/operators';
 import { LoginService, LoginResponse } from '../services/login.service';
 import { Hevelius } from '../../hevelius';
-import { MatSnackBar, MatSnackBarModule } from '@angular/material/snack-bar';
+import { MatSnackBar } from '@angular/material/snack-bar';
 import { HttpErrorResponse } from '@angular/common/http';
 import { MatButtonModule } from '@angular/material/button';
 import { MatInputModule } from '@angular/material/input';
@@ -24,7 +24,6 @@ import { MatIconModule } from '@angular/material/icon';
     ReactiveFormsModule,
     MatInputModule,
     MatButtonModule,
-    MatSnackBarModule,
     MatToolbarModule,
     MatCardModule,
     MatIconModule

--- a/src/app/login/login.component.ts
+++ b/src/app/login/login.component.ts
@@ -107,6 +107,10 @@ export class LoginComponent implements OnInit {
   }
 
 
+  goToForgotPassword() {
+    this.router.navigateByUrl('/forgot-password');
+  }
+
   showMessage(text: string) {
     this.snackBar.open(text, 'Close', {
       duration: 3000, // Duration in milliseconds

--- a/src/app/reset-password/reset-password.component.css
+++ b/src/app/reset-password/reset-password.component.css
@@ -1,0 +1,37 @@
+.auth-card {
+  max-width: 360px;
+  margin: 40px auto;
+}
+
+.auth-form {
+  display: flex;
+  flex-direction: column;
+}
+
+.full-width {
+  width: 100%;
+}
+
+.back-link {
+  text-align: center;
+  margin-top: 8px;
+}
+
+.link-button {
+  background: none;
+  border: none;
+  padding: 0;
+  color: #3f51b5;
+  text-decoration: underline;
+  cursor: pointer;
+  font-size: inherit;
+}
+
+@media (max-width: 640px) {
+  .auth-card {
+    max-width: 100%;
+    margin: 0;
+    border-radius: 0;
+    box-shadow: none;
+  }
+}

--- a/src/app/reset-password/reset-password.component.html
+++ b/src/app/reset-password/reset-password.component.html
@@ -1,0 +1,46 @@
+<mat-toolbar color="primary">
+  <mat-toolbar-row>
+    <span>{{ title }}</span>
+  </mat-toolbar-row>
+</mat-toolbar>
+
+<mat-card class="auth-card">
+  <mat-card-content>
+    @if (!token) {
+      <p>This reset link is missing or invalid. Please request a new one.</p>
+      <p class="back-link">
+        <button type="button" class="link-button" (click)="goToForgotPassword()">Request a new reset link</button>
+      </p>
+    } @else {
+      <form [formGroup]="form" (ngSubmit)="onSubmit()" class="auth-form">
+        <mat-form-field appearance="outline" class="full-width">
+          <mat-label>New password</mat-label>
+          <input matInput [type]="hide ? 'password' : 'text'" formControlName="new_password" autocomplete="new-password">
+          <button mat-icon-button matSuffix type="button" (click)="hide = !hide"
+                  [attr.aria-label]="'Hide password'" [attr.aria-pressed]="hide">
+            <mat-icon>{{ hide ? 'visibility_off' : 'visibility' }}</mat-icon>
+          </button>
+          @if (form.get('new_password')?.touched && form.get('new_password')?.hasError('minlength')) {
+            <mat-error>Password must be at least 8 characters.</mat-error>
+          }
+        </mat-form-field>
+
+        <mat-form-field appearance="outline" class="full-width">
+          <mat-label>Confirm new password</mat-label>
+          <input matInput [type]="hide ? 'password' : 'text'" formControlName="confirm_password" autocomplete="new-password">
+          @if (form.hasError('passwordMismatch') && form.get('confirm_password')?.touched) {
+            <mat-error>Passwords do not match.</mat-error>
+          }
+        </mat-form-field>
+
+        <button mat-raised-button color="primary" type="submit" [disabled]="submitting">
+          {{ submitting ? 'Saving…' : 'Set new password' }}
+        </button>
+      </form>
+    }
+
+    <p class="back-link">
+      <button type="button" class="link-button" (click)="goToLogin()">Back to login</button>
+    </p>
+  </mat-card-content>
+</mat-card>

--- a/src/app/reset-password/reset-password.component.spec.ts
+++ b/src/app/reset-password/reset-password.component.spec.ts
@@ -1,0 +1,104 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+import { HttpErrorResponse } from '@angular/common/http';
+import { ActivatedRoute, Router } from '@angular/router';
+import { of, throwError } from 'rxjs';
+import { convertToParamMap } from '@angular/router';
+import { ResetPasswordComponent } from './reset-password.component';
+import { LoginService } from '../services/login.service';
+import { MatSnackBar } from '@angular/material/snack-bar';
+
+describe('ResetPasswordComponent', () => {
+  let component: ResetPasswordComponent;
+  let fixture: ComponentFixture<ResetPasswordComponent>;
+  let loginService: { resetPassword: ReturnType<typeof vi.fn> };
+  let snackBar: { open: ReturnType<typeof vi.fn> };
+  let router: { navigateByUrl: ReturnType<typeof vi.fn> };
+
+  function configure(queryParams: Record<string, string>) {
+    return TestBed.configureTestingModule({
+      imports: [NoopAnimationsModule, ResetPasswordComponent],
+      providers: [
+        { provide: LoginService, useValue: loginService },
+        { provide: MatSnackBar, useValue: snackBar },
+        { provide: Router, useValue: router },
+        {
+          provide: ActivatedRoute,
+          useValue: { snapshot: { queryParamMap: convertToParamMap(queryParams) } }
+        }
+      ]
+    }).compileComponents();
+  }
+
+  beforeEach(() => {
+    loginService = { resetPassword: vi.fn() };
+    snackBar = { open: vi.fn() };
+    router = { navigateByUrl: vi.fn() };
+  });
+
+  it('shows a missing-link message when there is no token', async () => {
+    await configure({});
+    fixture = TestBed.createComponent(ResetPasswordComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+
+    expect(component.token).toBeNull();
+  });
+
+  it('rejects mismatched passwords before calling the API', async () => {
+    await configure({ token: 'abc123' });
+    fixture = TestBed.createComponent(ResetPasswordComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+
+    component.form.patchValue({ new_password: 'new-password-123', confirm_password: 'different' });
+    component.onSubmit();
+    await fixture.whenStable();
+
+    expect(loginService.resetPassword).not.toHaveBeenCalled();
+  });
+
+  it('submits the token and new password, then navigates to login on success', async () => {
+    await configure({ token: 'abc123' });
+    loginService.resetPassword.mockReturnValue(of({ status: true, msg: 'Password updated' }));
+    fixture = TestBed.createComponent(ResetPasswordComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+
+    component.form.patchValue({ new_password: 'new-password-123', confirm_password: 'new-password-123' });
+    component.onSubmit();
+    await fixture.whenStable();
+
+    expect(loginService.resetPassword).toHaveBeenCalledWith('abc123', 'new-password-123');
+    expect(router.navigateByUrl).toHaveBeenCalledWith('/login');
+  });
+
+  it('shows the backend error message when the token is invalid or expired', async () => {
+    await configure({ token: 'expired' });
+    loginService.resetPassword.mockReturnValue(of({ status: false, msg: 'Invalid or expired reset token' }));
+    fixture = TestBed.createComponent(ResetPasswordComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+
+    component.form.patchValue({ new_password: 'new-password-123', confirm_password: 'new-password-123' });
+    component.onSubmit();
+    await fixture.whenStable();
+
+    expect(router.navigateByUrl).not.toHaveBeenCalled();
+    expect(snackBar.open).toHaveBeenCalledWith('Invalid or expired reset token', 'Close', expect.anything());
+  });
+
+  it('shows a request-failed message on HTTP error', async () => {
+    await configure({ token: 'abc123' });
+    loginService.resetPassword.mockReturnValue(throwError(() => new HttpErrorResponse({ status: 500 })));
+    fixture = TestBed.createComponent(ResetPasswordComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+
+    component.form.patchValue({ new_password: 'new-password-123', confirm_password: 'new-password-123' });
+    component.onSubmit();
+    await fixture.whenStable();
+
+    expect(snackBar.open).toHaveBeenCalledWith('Request failed with error code: 500', 'Close', expect.anything());
+  });
+});

--- a/src/app/reset-password/reset-password.component.ts
+++ b/src/app/reset-password/reset-password.component.ts
@@ -1,0 +1,124 @@
+import { Component, OnInit, inject } from '@angular/core';
+import {
+    AbstractControl,
+    UntypedFormGroup,
+    ValidationErrors,
+    Validators,
+    UntypedFormBuilder,
+    ReactiveFormsModule
+} from '@angular/forms';
+import { ActivatedRoute, Router } from '@angular/router';
+import { first } from 'rxjs/operators';
+import { LoginService, StatusMsgResponse } from '../services/login.service';
+import { Hevelius } from '../../hevelius';
+import { MatSnackBar } from '@angular/material/snack-bar';
+import { HttpErrorResponse } from '@angular/common/http';
+import { MatButtonModule } from '@angular/material/button';
+import { MatFormFieldModule } from '@angular/material/form-field';
+import { MatInputModule } from '@angular/material/input';
+import { MatIconModule } from '@angular/material/icon';
+import { MatToolbarModule } from '@angular/material/toolbar';
+import { MatCardModule } from '@angular/material/card';
+
+/** Requires confirm_password to equal new_password. */
+function passwordsMatchValidator(group: AbstractControl): ValidationErrors | null {
+    const newPassword = group.get('new_password')?.value;
+    const confirm = group.get('confirm_password')?.value;
+    return newPassword && confirm && newPassword !== confirm ? { passwordMismatch: true } : null;
+}
+
+@Component({
+    selector: 'app-reset-password',
+    templateUrl: './reset-password.component.html',
+    styleUrls: ['./reset-password.component.css'],
+    standalone: true,
+    imports: [
+        ReactiveFormsModule,
+        MatFormFieldModule,
+        MatInputModule,
+        MatButtonModule,
+        MatIconModule,
+        MatToolbarModule,
+        MatCardModule
+    ]
+})
+export class ResetPasswordComponent implements OnInit {
+    private route = inject(ActivatedRoute);
+    private router = inject(Router);
+    private loginService = inject(LoginService);
+    private snackBar = inject(MatSnackBar);
+    private formBuilder = inject(UntypedFormBuilder);
+
+    title: string;
+    token: string | null = null;
+    submitting = false;
+    hide = true;
+    form: UntypedFormGroup;
+
+    constructor() {
+        this.title = Hevelius.title;
+    }
+
+    ngOnInit(): void {
+        this.token = this.route.snapshot.queryParamMap.get('token');
+
+        this.form = this.formBuilder.group(
+            {
+                new_password: ['', [Validators.required, Validators.minLength(8)]],
+                confirm_password: ['', Validators.required]
+            },
+            { validators: passwordsMatchValidator }
+        );
+    }
+
+    onSubmit(): void {
+        if (!this.token) {
+            this.showMessage('Missing or invalid reset link.');
+            return;
+        }
+        if (this.form.invalid) {
+            this.form.markAllAsTouched();
+            return;
+        }
+
+        this.submitting = true;
+        this.loginService
+            .resetPassword(this.token, this.form.controls.new_password.value)
+            .pipe(first())
+            .subscribe({
+                next: (data: StatusMsgResponse) => {
+                    this.submitting = false;
+                    if (data.status) {
+                        this.showMessage('Password updated. Please sign in with your new password.');
+                        this.router.navigateByUrl('/login');
+                    } else {
+                        this.showMessage(data.msg || 'Invalid or expired reset link.');
+                    }
+                },
+                error: (error: HttpErrorResponse) => {
+                    this.submitting = false;
+                    if (error.status === 0) {
+                        this.showMessage('Backend is unresponsive. Please check the server.');
+                    } else {
+                        this.showMessage(`Request failed with error code: ${error.status}`);
+                    }
+                }
+            });
+    }
+
+    goToLogin(): void {
+        this.router.navigateByUrl('/login');
+    }
+
+    goToForgotPassword(): void {
+        this.router.navigateByUrl('/forgot-password');
+    }
+
+    showMessage(text: string): void {
+        this.snackBar.open(text, 'Close', {
+            duration: 5000,
+            horizontalPosition: 'center',
+            verticalPosition: 'bottom'
+        });
+    }
+}

--- a/src/app/services/login.service.spec.ts
+++ b/src/app/services/login.service.spec.ts
@@ -42,4 +42,26 @@ describe('LoginService', () => {
     service.maybeRefreshToken();
     httpMock.expectNone(Hevelius.apiUrl + '/login/refresh');
   });
+
+  it('forgotPassword posts the login/email to the forgot-password endpoint', () => {
+    service.forgotPassword('user1').subscribe(res => {
+      expect(res.status).toBe(true);
+    });
+
+    const req = httpMock.expectOne(Hevelius.apiUrl + '/auth/forgot-password');
+    expect(req.request.method).toBe('POST');
+    expect(req.request.body).toEqual({ login_or_email: 'user1' });
+    req.flush({ status: true, msg: 'If that account exists, a password reset email has been sent.' });
+  });
+
+  it('resetPassword posts the token and new password to the password-reset endpoint', () => {
+    service.resetPassword('abc123', 'new-password-123').subscribe(res => {
+      expect(res.status).toBe(true);
+    });
+
+    const req = httpMock.expectOne(Hevelius.apiUrl + '/auth/password-reset');
+    expect(req.request.method).toBe('POST');
+    expect(req.request.body).toEqual({ token: 'abc123', new_password: 'new-password-123' });
+    req.flush({ status: true, msg: 'Password updated' });
+  });
 });

--- a/src/app/services/login.service.ts
+++ b/src/app/services/login.service.ts
@@ -34,6 +34,11 @@ interface CurrentUser {
     phone?: string;
 }
 
+export interface StatusMsgResponse {
+    status: boolean;
+    msg?: string;
+}
+
 @Injectable({
     providedIn: 'root'
 })
@@ -118,6 +123,23 @@ export class LoginService {
 
     isLoggedIn(): boolean {
         return !!this.getToken();
+    }
+
+    // Request a password reset email for a login or email address. Does not
+    // require authentication; the backend always returns a generic response
+    // (whether or not the account exists) to avoid account enumeration.
+    forgotPassword(loginOrEmail: string): Observable<StatusMsgResponse> {
+        return this.http.post<StatusMsgResponse>(Hevelius.apiUrl + '/auth/forgot-password', {
+            login_or_email: loginOrEmail
+        });
+    }
+
+    // Complete a password reset using the one-time token from the forgot-password email.
+    resetPassword(token: string, newPassword: string): Observable<StatusMsgResponse> {
+        return this.http.post<StatusMsgResponse>(Hevelius.apiUrl + '/auth/password-reset', {
+            token,
+            new_password: newPassword
+        });
     }
 
     getBackendVersion(): Observable<string> {

--- a/src/app/services/user.service.spec.ts
+++ b/src/app/services/user.service.spec.ts
@@ -1,0 +1,81 @@
+import { TestBed } from '@angular/core/testing';
+import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
+import { provideHttpClient, withInterceptorsFromDi } from '@angular/common/http';
+import { UserService } from './user.service';
+import { Hevelius } from 'src/hevelius';
+
+describe('UserService', () => {
+  let service: UserService;
+  let httpMock: HttpTestingController;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [provideHttpClient(withInterceptorsFromDi()), provideHttpClientTesting()]
+    });
+    service = TestBed.inject(UserService);
+    httpMock = TestBed.inject(HttpTestingController);
+  });
+
+  afterEach(() => {
+    httpMock.verify();
+  });
+
+  it('getProfile fetches the current user profile', () => {
+    service.getProfile().subscribe(profile => {
+      expect(profile.login).toBe('user1');
+      expect(profile.phone).toBe('555-0100');
+    });
+
+    const req = httpMock.expectOne(`${Hevelius.apiUrl}/users/me`);
+    expect(req.request.method).toBe('GET');
+    req.flush({
+      user_id: 1,
+      login: 'user1',
+      firstname: 'Ada',
+      lastname: 'Lovelace',
+      share: 0,
+      phone: '555-0100',
+      email: 'ada@example.com',
+      permissions: 0,
+      aavso_id: 'AA001',
+      login_enabled: true
+    });
+  });
+
+  it('updateProfile PATCHes the profile fields', () => {
+    service
+      .updateProfile({ firstname: 'Ada', phone: '555-0100' })
+      .subscribe(profile => {
+        expect(profile.firstname).toBe('Ada');
+      });
+
+    const req = httpMock.expectOne(`${Hevelius.apiUrl}/users/me`);
+    expect(req.request.method).toBe('PATCH');
+    expect(req.request.body).toEqual({ firstname: 'Ada', phone: '555-0100' });
+    req.flush({
+      user_id: 1,
+      login: 'user1',
+      firstname: 'Ada',
+      lastname: 'Lovelace',
+      share: 0,
+      phone: '555-0100',
+      email: 'ada@example.com',
+      permissions: 0,
+      aavso_id: 'AA001',
+      login_enabled: true
+    });
+  });
+
+  it('changePassword POSTs current and new password', () => {
+    service
+      .changePassword({ current_password: 'old-pw', new_password: 'new-password-123' })
+      .subscribe(response => {
+        expect(response.status).toBe(true);
+      });
+
+    const req = httpMock.expectOne(`${Hevelius.apiUrl}/users/me/password`);
+    expect(req.request.method).toBe('POST');
+    expect(req.request.body).toEqual({ current_password: 'old-pw', new_password: 'new-password-123' });
+    req.flush({ status: true, msg: 'Password updated' });
+  });
+});

--- a/src/app/services/user.service.ts
+++ b/src/app/services/user.service.ts
@@ -1,0 +1,53 @@
+import { Injectable, inject } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { Observable } from 'rxjs';
+import { Hevelius } from 'src/hevelius';
+import { StatusMsgResponse } from './login.service';
+
+// See UsersMeResource / UsersMePasswordResource in hevelius-backend's
+// hevelius/api/routes/auth_users.py for the source of truth.
+export interface UserProfile {
+  user_id: number;
+  login: string | null;
+  firstname: string | null;
+  lastname: string | null;
+  share: number | null;
+  phone: string | null;
+  email: string | null;
+  permissions: number;
+  aavso_id: string | null;
+  login_enabled: boolean;
+}
+
+export interface UserProfileUpdate {
+  firstname?: string | null;
+  lastname?: string | null;
+  phone?: string | null;
+  email?: string | null;
+  aavso_id?: string | null;
+}
+
+export interface PasswordChangeRequest {
+  current_password: string;
+  new_password: string;
+}
+
+@Injectable({
+  providedIn: 'root'
+})
+export class UserService {
+  private http = inject(HttpClient);
+  private apiUrl = `${Hevelius.apiUrl}/users/me`;
+
+  getProfile(): Observable<UserProfile> {
+    return this.http.get<UserProfile>(this.apiUrl);
+  }
+
+  updateProfile(body: UserProfileUpdate): Observable<UserProfile> {
+    return this.http.patch<UserProfile>(this.apiUrl, body);
+  }
+
+  changePassword(body: PasswordChangeRequest): Observable<StatusMsgResponse> {
+    return this.http.post<StatusMsgResponse>(`${this.apiUrl}/password`, body);
+  }
+}


### PR DESCRIPTION
## Summary

Frontend for borowka-obs/hevelius-backend#105 (backend: `PATCH /api/users/me` with `phone`, `POST /api/users/me/password`, new `POST /api/auth/forgot-password`).

- **User page (`/user`)** is now an editable form: first name, last name, phone, e-mail, AAVSO observer ID, with a Save button (`PATCH /api/users/me`), plus a separate change-password form (current + new + confirm password, `POST /api/users/me/password`). Loads live data from `GET /api/users/me` and falls back to the cached login response if that's unreachable, so the page never shows blank fields.
- **Forgot password** (`/forgot-password`, public route): enter your username or e-mail; always shows the same generic confirmation regardless of whether the account exists (matches the backend's anti-enumeration behavior). Linked from the login page ("Forgot your password?").
- **Reset password** (`/reset-password?token=...`, public route): reads the token from the query string, lets you set + confirm a new password (client-side match validation, 8-char minimum mirroring the backend), and redirects to `/login` on success. Shows a clear message if the link is missing/invalid.
- New `UserService` (`getProfile`/`updateProfile`/`changePassword`) and two additions to `LoginService` (`forgotPassword`/`resetPassword`).

## Test plan

- [x] `ng build` — succeeds
- [x] `ng lint` — clean
- [x] `ng test` — 218/218 passing, including new specs for `UserService`, `LoginService`'s new methods, `UserComponent`, `ForgotPasswordComponent`, `ResetPasswordComponent`
- [x] Manually exercised all four pages (`/login`, `/forgot-password`, `/reset-password`, `/user`) with `ng serve` + a headless browser at both a desktop (1280×900) and mobile (390×844) viewport — profile/password forms collapse to a single column and cards go edge-to-edge on narrow screens; login/forgot/reset stay centered and usable on desktop

---
_Generated by [Claude Code](https://claude.ai/code/session_014i2j64ME7BouaUAC2AdT9s)_