### PR TITLE
Make lists more phone-friendly

### DIFF
--- a/src/app/components/asteroids-list/asteroids-list.component.css
+++ b/src/app/components/asteroids-list/asteroids-list.component.css
@@ -2,6 +2,15 @@
   padding: 20px;
 }
 
+.search-bar {
+  margin-bottom: 12px;
+}
+
+.search-field {
+  width: 100%;
+  max-width: 400px;
+}
+
 .filters {
   margin-bottom: 20px;
   overflow: hidden;

--- a/src/app/components/asteroids-list/asteroids-list.component.html
+++ b/src/app/components/asteroids-list/asteroids-list.component.html
@@ -1,11 +1,13 @@
 <div class="container">
+  <div class="search-bar">
+    <mat-form-field class="search-field" subscriptSizing="dynamic" appearance="outline">
+      <mat-label>Search asteroids</mat-label>
+      <input matInput [formControl]="searchControl" placeholder="Filter by designation…">
+    </mat-form-field>
+  </div>
+
   <div class="filters" [@filterExpand]="isFilterVisible ? 'expanded' : 'collapsed'">
     <form [formGroup]="filterForm" class="filter-form" (ngSubmit)="onFilterSubmit($event)">
-      <mat-form-field class="filter-field" subscriptSizing="dynamic">
-        <mat-label>Designation</mat-label>
-        <input matInput formControlName="designation" type="text" placeholder="e.g. 00001">
-      </mat-form-field>
-
       <mat-form-field class="filter-field filter-field-narrow" subscriptSizing="dynamic">
         <mat-label>Number</mat-label>
         <input matInput formControlName="number" type="number" step="1" min="1">

--- a/src/app/components/asteroids-list/asteroids-list.component.ts
+++ b/src/app/components/asteroids-list/asteroids-list.component.ts
@@ -5,7 +5,8 @@ import { MatSortModule, Sort } from '@angular/material/sort';
 import { MatPaginatorModule, PageEvent } from '@angular/material/paginator';
 import { MatChipsModule } from '@angular/material/chips';
 import { Subscription } from 'rxjs';
-import { FormBuilder, FormGroup, ReactiveFormsModule } from '@angular/forms';
+import { FormBuilder, FormControl, FormGroup, ReactiveFormsModule } from '@angular/forms';
+import { debounceTime, distinctUntilChanged } from 'rxjs/operators';
 import { trigger, state, style, transition, animate } from '@angular/animations';
 import { TopBarService } from '../../services/top-bar.service';
 import { MatTableModule } from '@angular/material/table';
@@ -97,9 +98,21 @@ export class AsteroidsListComponent implements OnInit, OnDestroy {
   private subscriptions: Subscription[] = [];
   filterForm: FormGroup;
   isFilterVisible = false;
+  /** Quick search by designation, mirroring the projects list search bar. */
+  searchControl = new FormControl('');
 
   constructor() {
     this.initFilterForm();
+
+    this.subscriptions.push(
+      this.searchControl.valueChanges.pipe(
+        debounceTime(300),
+        distinctUntilChanged()
+      ).subscribe(value => {
+        this.filterForm.patchValue({ designation: value }, { emitEvent: false });
+        this.applyFilters();
+      })
+    );
 
     setTimeout(() => {
       this.topBarService.updateState({
@@ -192,6 +205,7 @@ export class AsteroidsListComponent implements OnInit, OnDestroy {
 
   clearFilters() {
     this.filterError = null;
+    this.searchControl.setValue('', { emitEvent: false });
     this.filterForm.reset({
       designation: null,
       number: null,

--- a/src/app/components/project-detail/project-detail.component.css
+++ b/src/app/components/project-detail/project-detail.component.css
@@ -70,3 +70,26 @@ table {
   margin-top: 4px;
   font-size: 0.85rem;
 }
+
+.subframes-section .table-container {
+  overflow-x: auto;
+}
+
+@media (max-width: 640px) {
+  .container {
+    padding: 8px;
+  }
+
+  .progress-cell {
+    min-width: 100px;
+  }
+
+  table {
+    font-size: 0.85rem;
+  }
+
+  .mat-mdc-header-cell,
+  .mat-mdc-cell {
+    padding: 4px 6px !important;
+  }
+}

--- a/src/app/components/project-detail/project-detail.component.html
+++ b/src/app/components/project-detail/project-detail.component.html
@@ -93,6 +93,7 @@
           Add subframe
         </button>
       </div>
+      <div class="table-container">
       <table mat-table [dataSource]="getSubframes()" class="mat-elevation-z8">
         <ng-container matColumnDef="filter">
           <th mat-header-cell *matHeaderCellDef>Filter</th>
@@ -151,6 +152,7 @@
           <td class="mat-cell" [attr.colspan]="subframesColumns.length">No subframes. Click "Add subframe" to add one.</td>
         </tr>
       </table>
+      </div>
     </div>
 
     <div class="tasks-section">

--- a/src/app/components/project-detail/project-detail.component.ts
+++ b/src/app/components/project-detail/project-detail.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit, inject } from '@angular/core';
+import { Component, OnInit, HostListener, inject } from '@angular/core';
 import { DatePipe } from '@angular/common';
 import { ActivatedRoute, Router, RouterModule } from '@angular/router';
 import { ProjectsService } from '../../services/projects.service';
@@ -64,8 +64,22 @@ export class ProjectDetailComponent implements OnInit {
   projectNavigation: Project[] = [];
   currentProjectIndex = -1;
   telescope: Telescope | null = null;
+
+  private readonly MOBILE_BREAKPOINT = 640;
+  isMobile = typeof window !== 'undefined' && window.innerWidth <= this.MOBILE_BREAKPOINT;
+
+  @HostListener('window:resize')
+  onResize(): void {
+    this.isMobile = window.innerWidth <= this.MOBILE_BREAKPOINT;
+  }
+
   /** Must match every `matColumnDef` in the template — extra or missing keys break the table. */
-  subframesColumns: string[] = ['filter', 'exposure_time', 'goal_count', 'progress', 'active', 'actions'];
+  get subframesColumns(): string[] {
+    if (this.isMobile) {
+      return ['filter', 'progress', 'actions'];
+    }
+    return ['filter', 'exposure_time', 'goal_count', 'progress', 'active', 'actions'];
+  }
 
   ngOnInit(): void {
     this.loadProjectNavigation();

--- a/src/app/components/sensors-list/sensors-list.component.ts
+++ b/src/app/components/sensors-list/sensors-list.component.ts
@@ -63,7 +63,7 @@ export class SensorsListComponent implements OnInit, OnDestroy {
 
   get displayedColumns(): string[] {
     if (this.isMobile) {
-      return ['name', 'vendor', 'resolution', 'active', 'actions'];
+      return ['name', 'resolution', 'pixel_size', 'actions'];
     }
     return ['name', 'vendor', 'resolution', 'pixel_size', 'sensor_size', 'bits', 'active', 'actions'];
   }

--- a/src/app/components/telescope-list/telescope-list.component.css
+++ b/src/app/components/telescope-list/telescope-list.component.css
@@ -69,6 +69,60 @@ table {
   cursor: pointer;
 }
 
+.mobile-cards {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  margin-top: 0.5rem;
+}
+
+.telescope-card {
+  background: var(--mat-sys-surface);
+  border: 1px solid var(--mat-sys-outline-variant);
+  border-radius: 6px;
+  padding: 12px 14px;
+  cursor: pointer;
+  transition: background 0.15s;
+}
+
+.telescope-card:active {
+  background: var(--mat-sys-surface-container-high);
+}
+
+.card-line1 {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 8px;
+}
+
+.card-name {
+  font-weight: 500;
+  color: var(--mat-sys-primary);
+  font-size: 1rem;
+}
+
+.card-line2 {
+  margin-top: 3px;
+  font-size: 0.85rem;
+  color: var(--mat-sys-on-surface-variant);
+}
+
+.card-description {
+  margin-top: 4px;
+  font-size: 0.8rem;
+  color: var(--mat-sys-on-surface-variant);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.no-results {
+  padding: 24px;
+  text-align: center;
+  color: var(--mat-sys-on-surface-variant);
+}
+
 @media (max-width: 640px) {
   .container {
     padding: 8px;

--- a/src/app/components/telescope-list/telescope-list.component.html
+++ b/src/app/components/telescope-list/telescope-list.component.html
@@ -9,6 +9,28 @@
     </form>
   </div>
 
+  @if (isMobile) {
+    <div class="mobile-cards">
+      @for (telescope of dataSource.data; track telescope.scope_id) {
+        <div class="telescope-card" (click)="openTelescope(telescope)" (keyup.enter)="openTelescope(telescope)" tabindex="0" role="button">
+          <div class="card-line1">
+            <span class="card-name">{{ telescope.name }}</span>
+            <mat-icon [style.color]="telescope.active ? 'green' : 'red'">
+              {{ telescope.active ? 'check_circle' : 'cancel' }}
+            </mat-icon>
+          </div>
+          <div class="card-line2">
+            {{ getOpticsLabel(telescope) }} · {{ telescope.sensor?.name ?? '-' }}
+          </div>
+          @if (telescope.descr) {
+            <div class="card-description">{{ telescope.descr }}</div>
+          }
+        </div>
+      } @empty {
+        <div class="no-results">No telescopes found.</div>
+      }
+    </div>
+  } @else {
   <div class="table-container">
     <table mat-table [dataSource]="dataSource" matSort (matSortChange)="onSortChange($event)" class="mat-elevation-z8">
       <ng-container matColumnDef="name">
@@ -57,4 +79,5 @@
       <tr mat-row *matRowDef="let row; columns: displayedColumns;"></tr>
     </table>
   </div>
+  }
 </div>

--- a/src/app/components/telescope-list/telescope-list.component.ts
+++ b/src/app/components/telescope-list/telescope-list.component.ts
@@ -1,4 +1,5 @@
-import { Component, OnInit, OnDestroy, inject } from '@angular/core';
+import { Component, OnInit, OnDestroy, HostListener, inject } from '@angular/core';
+import { Router, RouterModule } from '@angular/router';
 import { TelescopeService, Telescope, TelescopesListParams } from '../../services/telescope.service';
 import { MatTableDataSource, MatTableModule } from '@angular/material/table';
 import { MatSortModule, Sort } from '@angular/material/sort';
@@ -8,7 +9,6 @@ import { MatCheckboxModule } from '@angular/material/checkbox';
 import { MatButtonModule } from '@angular/material/button';
 import { MatTooltipModule } from '@angular/material/tooltip';
 import { MatDialog } from '@angular/material/dialog';
-import { RouterModule } from '@angular/router';
 import { trigger, state, style, transition, animate } from '@angular/animations';
 import { TopBarService } from '../../services/top-bar.service';
 import { TelescopeFormDialogComponent } from '../telescope-form-dialog/telescope-form-dialog.component';
@@ -51,19 +51,25 @@ export class TelescopeListComponent implements OnInit, OnDestroy {
   private fb = inject(FormBuilder);
   private topBarService = inject(TopBarService);
   private dialog = inject(MatDialog);
+  private router = inject(Router);
 
   dataSource = new MatTableDataSource<Telescope>();
   allTelescopes: Telescope[] = [];
-  displayedColumns: string[] = [
-    'name',
-    'descr',
-    'optics',
-    'min_dec',
-    'max_dec',
-    'sensor',
-    'active',
-    'actions'
-  ];
+
+  private readonly MOBILE_BREAKPOINT = 640;
+  isMobile = typeof window !== 'undefined' && window.innerWidth <= this.MOBILE_BREAKPOINT;
+
+  get displayedColumns(): string[] {
+    if (this.isMobile) {
+      return ['name', 'optics', 'sensor', 'active'];
+    }
+    return ['name', 'descr', 'optics', 'min_dec', 'max_dec', 'sensor', 'active', 'actions'];
+  }
+
+  @HostListener('window:resize')
+  onResize(): void {
+    this.isMobile = window.innerWidth <= this.MOBILE_BREAKPOINT;
+  }
 
   currentSort: { sort_by: TelescopesListParams['sort_by']; sort_order: 'asc' | 'desc' } = {
     sort_by: 'scope_id',
@@ -91,6 +97,10 @@ export class TelescopeListComponent implements OnInit, OnDestroy {
   openAddTelescope(): void {
     const ref = this.dialog.open(TelescopeFormDialogComponent, { width: '480px', data: { mode: 'add' } });
     ref.afterClosed().subscribe(created => { if (created) this.loadTelescopes(); });
+  }
+
+  openTelescope(telescope: Telescope): void {
+    this.router.navigate(['/scopes', telescope.scope_id]);
   }
 
   openEditTelescope(telescope: Telescope): void {


### PR DESCRIPTION
- Narrow the project detail subframes table on mobile (fewer columns,
  tighter padding), matching the responsive pattern used elsewhere.
- Add a card-based mobile view to the telescope list, mirroring the
  projects list's narrow layout.
- Sensors list mobile columns now skip vendor/active and show pixel size
  instead.
- Asteroids list gains an always-visible, debounced quick search bar
  like the projects list, replacing the buried designation filter field.