### PR TITLE
Add project name field to edit dialog

### DIFF
--- a/src/app/components/project-detail/project-detail.component.ts
+++ b/src/app/components/project-detail/project-detail.component.ts
@@ -183,6 +183,7 @@ export class ProjectDetailComponent implements OnInit {
       width: '520px',
       data: {
         projectId: this.project.project_id,
+        initialName: this.project.name,
         initialScopeId: this.project.scope_id,
         initialDescription: this.project.description ?? null,
         initialRa: this.project.ra,

--- a/src/app/components/project-edit-dialog/project-edit-dialog.component.html
+++ b/src/app/components/project-edit-dialog/project-edit-dialog.component.html
@@ -2,6 +2,14 @@
 <mat-dialog-content>
   <form [formGroup]="form" class="dialog-form">
     <mat-form-field appearance="outline" class="full-width" subscriptSizing="dynamic">
+      <mat-label>Name</mat-label>
+      <input matInput formControlName="name" required>
+      @if (form.get('name')?.touched && form.get('name')?.hasError('required')) {
+        <mat-error>Name is required</mat-error>
+      }
+    </mat-form-field>
+
+    <mat-form-field appearance="outline" class="full-width" subscriptSizing="dynamic">
       <mat-label>Telescope</mat-label>
       <mat-select formControlName="scope_id" required>
         @for (t of activeTelescopes; track t.scope_id) {

--- a/src/app/components/project-edit-dialog/project-edit-dialog.component.spec.ts
+++ b/src/app/components/project-edit-dialog/project-edit-dialog.component.spec.ts
@@ -9,6 +9,7 @@ import { ProjectEditDialogComponent } from './project-edit-dialog.component';
 
 const DEFAULT_DATA = {
   projectId: 42,
+  initialName: 'M31',
   initialScopeId: 2,
   initialDescription: null,
   initialRa: 0.712,
@@ -95,8 +96,26 @@ describe('ProjectEditDialogComponent', () => {
     component.save();
     expect(projectsService.updateProject).toHaveBeenCalledWith(
       42,
-      expect.objectContaining({ scope_id: 2, ra: 0.712, decl: 41.27, active: true })
+      expect.objectContaining({ name: 'M31', scope_id: 2, ra: 0.712, decl: 41.27, active: true })
     );
+  });
+
+  it('pre-fills name from dialog data', () => {
+    expect(component.form.get('name')?.value).toBe('M31');
+  });
+
+  it('save includes the edited name in the update payload', () => {
+    component.form.patchValue({ name: 'M31 Renamed', scope_id: 2, ra: '0.712', decl: '41.27', active: true, regexps: '', start_date: '', end_date: '', publications: '' });
+    component.save();
+    expect(projectsService.updateProject).toHaveBeenCalledWith(
+      42,
+      expect.objectContaining({ name: 'M31 Renamed' })
+    );
+  });
+
+  it('marks the form invalid when name is cleared', () => {
+    component.form.patchValue({ name: '' });
+    expect(component.form.get('name')?.hasError('required')).toBe(true);
   });
 
   it('save includes description in the update payload', () => {

--- a/src/app/components/project-edit-dialog/project-edit-dialog.component.ts
+++ b/src/app/components/project-edit-dialog/project-edit-dialog.component.ts
@@ -40,6 +40,7 @@ export class DeleteProjectConfirmDialogComponent {}
 
 export interface ProjectEditDialogData {
   projectId: number;
+  initialName: string;
   initialScopeId: number;
   initialDescription?: string | null;
   initialRa?: number;
@@ -146,6 +147,7 @@ export class ProjectEditDialogComponent {
         ? String(this.dialogData.initialRotation)
         : '';
     this.form = this.fb.group({
+      name: [this.dialogData.initialName, Validators.required],
       scope_id: [this.dialogData.initialScopeId, Validators.required],
       description: [this.dialogData.initialDescription ?? ''],
       regexps: [this.dialogData.initialRegexps ?? ''],
@@ -251,6 +253,7 @@ export class ProjectEditDialogComponent {
       return Number.isFinite(n) ? n : null;
     };
     const body: ProjectUpdate = {
+      name: String(v.name ?? '').trim(),
       scope_id: Number(v.scope_id),
       description: String(v.description ?? '').trim(),
       regexps: String(v.regexps ?? '').trim(),


### PR DESCRIPTION
## Summary
This PR adds the ability to edit a project's name through the project edit dialog. Previously, the name field was not included in the dialog, preventing users from modifying project names.

## Key Changes
- **Added name field to dialog form**: Introduced a new Material form field in the edit dialog template with required validation
- **Updated dialog data interface**: Extended `ProjectEditDialogData` to include `initialName` property
- **Initialized form control**: Added `name` form control to the reactive form with required validator and initial value from dialog data
- **Updated save payload**: Modified the project update request to include the name field
- **Passed initial name**: Updated `ProjectDetailComponent` to pass the current project name when opening the edit dialog
- **Added comprehensive tests**: Included three new test cases covering:
  - Pre-filling the name field from dialog data
  - Including edited name in the update payload
  - Form validation when name is cleared

## Implementation Details
- The name field is placed at the top of the form for logical organization
- Required validation is enforced with user-friendly error messaging
- The name value is trimmed before being sent to the API to handle whitespace
- All changes follow the existing code patterns and Material Design conventions used in the component

https://claude.ai/code/session_016rPQec6Ue4vrn6fDBDZR1Q