### PR TITLE
Let users edit default telescope, filter, and exposure on the User page

### DIFF
--- a/src/app/components/user/user.component.html
+++ b/src/app/components/user/user.component.html
@@ -204,80 +204,57 @@
     </div>
 
     <div [formGroup]="preferencesForm">
-
-      <div class="detail-row">
-        <div class="detail-label">Default telescope</div>
-        @if (editingPreference === 'default_scope') {
-          <mat-form-field appearance="outline" class="detail-input">
-            <mat-select formControlName="default_scope">
-              <mat-option [value]="null">—</mat-option>
-              @for (t of telescopes; track t.scope_id) {
-                <mat-option [value]="t.scope_id">{{ t.name }}</mat-option>
+      @for (pref of preferenceFields; track pref.field) {
+        <div class="detail-row">
+          <div class="detail-label">{{ preferenceFieldLabels[pref.field] }}</div>
+          @if (editingPreference === pref.field) {
+            <mat-form-field appearance="outline" class="detail-input">
+              @switch (pref.kind) {
+                @case ('scope') {
+                  <mat-select formControlName="default_scope">
+                    <mat-option [value]="null">—</mat-option>
+                    @for (t of telescopes; track t.scope_id) {
+                      <mat-option [value]="t.scope_id">{{ t.name }}</mat-option>
+                    }
+                  </mat-select>
+                }
+                @case ('filter') {
+                  <mat-select formControlName="default_filter">
+                    <mat-option [value]="null">—</mat-option>
+                    @for (f of filters; track f.filter_id) {
+                      <mat-option [value]="f.filter_id">{{ f.short_name }}</mat-option>
+                    }
+                  </mat-select>
+                }
+                @case ('exposure') {
+                  <input matInput type="number" min="1" step="1" formControlName="default_exposure"
+                         (keyup.enter)="savePreference('default_exposure')">
+                  @if (preferencesForm.get('default_exposure')?.hasError('min')) {
+                    <mat-error>Must be at least 1 second.</mat-error>
+                  }
+                  @if (preferencesForm.get('default_exposure')?.hasError('integer')) {
+                    <mat-error>Must be a whole number of seconds.</mat-error>
+                  }
+                }
               }
-            </mat-select>
-          </mat-form-field>
-          <button mat-icon-button color="primary" (click)="savePreference('default_scope')" [disabled]="savingPreference" aria-label="Save default telescope">
-            <mat-icon>check</mat-icon>
-          </button>
-          <button mat-icon-button (click)="cancelEditPreference('default_scope')" aria-label="Cancel">
-            <mat-icon>close</mat-icon>
-          </button>
-        } @else {
-          <div class="detail-value">{{ displayScope(preferences?.default_scope ?? null) }}</div>
-          <button mat-icon-button class="edit-btn" (click)="startEditPreference('default_scope')" aria-label="Edit default telescope">
-            <mat-icon>edit</mat-icon>
-          </button>
-        }
-      </div>
-
-      <div class="detail-row">
-        <div class="detail-label">Default filter</div>
-        @if (editingPreference === 'default_filter') {
-          <mat-form-field appearance="outline" class="detail-input">
-            <mat-select formControlName="default_filter">
-              <mat-option [value]="null">—</mat-option>
-              @for (f of filters; track f.filter_id) {
-                <mat-option [value]="f.filter_id">{{ f.short_name }}</mat-option>
-              }
-            </mat-select>
-          </mat-form-field>
-          <button mat-icon-button color="primary" (click)="savePreference('default_filter')" [disabled]="savingPreference" aria-label="Save default filter">
-            <mat-icon>check</mat-icon>
-          </button>
-          <button mat-icon-button (click)="cancelEditPreference('default_filter')" aria-label="Cancel">
-            <mat-icon>close</mat-icon>
-          </button>
-        } @else {
-          <div class="detail-value">{{ displayFilter(preferences?.default_filter ?? null) }}</div>
-          <button mat-icon-button class="edit-btn" (click)="startEditPreference('default_filter')" aria-label="Edit default filter">
-            <mat-icon>edit</mat-icon>
-          </button>
-        }
-      </div>
-
-      <div class="detail-row">
-        <div class="detail-label">Default exposure</div>
-        @if (editingPreference === 'default_exposure') {
-          <mat-form-field appearance="outline" class="detail-input">
-            <input matInput type="number" min="1" formControlName="default_exposure" (keyup.enter)="savePreference('default_exposure')">
-            @if (preferencesForm.get('default_exposure')?.hasError('min')) {
-              <mat-error>Must be at least 1 second.</mat-error>
-            }
-          </mat-form-field>
-          <button mat-icon-button color="primary" (click)="savePreference('default_exposure')" [disabled]="savingPreference" aria-label="Save default exposure">
-            <mat-icon>check</mat-icon>
-          </button>
-          <button mat-icon-button (click)="cancelEditPreference('default_exposure')" aria-label="Cancel">
-            <mat-icon>close</mat-icon>
-          </button>
-        } @else {
-          <div class="detail-value">{{ displayExposure(preferences?.default_exposure ?? null) }}</div>
-          <button mat-icon-button class="edit-btn" (click)="startEditPreference('default_exposure')" aria-label="Edit default exposure">
-            <mat-icon>edit</mat-icon>
-          </button>
-        }
-      </div>
-
+            </mat-form-field>
+            <button mat-icon-button color="primary" (click)="savePreference(pref.field)"
+                    [disabled]="savingPreference"
+                    [attr.aria-label]="'Save ' + preferenceFieldLabels[pref.field]">
+              <mat-icon>check</mat-icon>
+            </button>
+            <button mat-icon-button (click)="cancelEditPreference(pref.field)" aria-label="Cancel">
+              <mat-icon>close</mat-icon>
+            </button>
+          } @else {
+            <div class="detail-value">{{ displayPreference(pref.field) }}</div>
+            <button mat-icon-button class="edit-btn" (click)="startEditPreference(pref.field)"
+                    [attr.aria-label]="'Edit ' + preferenceFieldLabels[pref.field]">
+              <mat-icon>edit</mat-icon>
+            </button>
+          }
+        </div>
+      }
     </div>
   </div>
 </mat-card>

--- a/src/app/components/user/user.component.html
+++ b/src/app/components/user/user.component.html
@@ -202,5 +202,82 @@
         </mat-button-toggle>
       </mat-button-toggle-group>
     </div>
+
+    <div [formGroup]="preferencesForm">
+
+      <div class="detail-row">
+        <div class="detail-label">Default telescope</div>
+        @if (editingPreference === 'default_scope') {
+          <mat-form-field appearance="outline" class="detail-input">
+            <mat-select formControlName="default_scope">
+              <mat-option [value]="null">—</mat-option>
+              @for (t of telescopes; track t.scope_id) {
+                <mat-option [value]="t.scope_id">{{ t.name }}</mat-option>
+              }
+            </mat-select>
+          </mat-form-field>
+          <button mat-icon-button color="primary" (click)="savePreference('default_scope')" [disabled]="savingPreference" aria-label="Save default telescope">
+            <mat-icon>check</mat-icon>
+          </button>
+          <button mat-icon-button (click)="cancelEditPreference('default_scope')" aria-label="Cancel">
+            <mat-icon>close</mat-icon>
+          </button>
+        } @else {
+          <div class="detail-value">{{ displayScope(preferences?.default_scope ?? null) }}</div>
+          <button mat-icon-button class="edit-btn" (click)="startEditPreference('default_scope')" aria-label="Edit default telescope">
+            <mat-icon>edit</mat-icon>
+          </button>
+        }
+      </div>
+
+      <div class="detail-row">
+        <div class="detail-label">Default filter</div>
+        @if (editingPreference === 'default_filter') {
+          <mat-form-field appearance="outline" class="detail-input">
+            <mat-select formControlName="default_filter">
+              <mat-option [value]="null">—</mat-option>
+              @for (f of filters; track f.filter_id) {
+                <mat-option [value]="f.filter_id">{{ f.short_name }}</mat-option>
+              }
+            </mat-select>
+          </mat-form-field>
+          <button mat-icon-button color="primary" (click)="savePreference('default_filter')" [disabled]="savingPreference" aria-label="Save default filter">
+            <mat-icon>check</mat-icon>
+          </button>
+          <button mat-icon-button (click)="cancelEditPreference('default_filter')" aria-label="Cancel">
+            <mat-icon>close</mat-icon>
+          </button>
+        } @else {
+          <div class="detail-value">{{ displayFilter(preferences?.default_filter ?? null) }}</div>
+          <button mat-icon-button class="edit-btn" (click)="startEditPreference('default_filter')" aria-label="Edit default filter">
+            <mat-icon>edit</mat-icon>
+          </button>
+        }
+      </div>
+
+      <div class="detail-row">
+        <div class="detail-label">Default exposure</div>
+        @if (editingPreference === 'default_exposure') {
+          <mat-form-field appearance="outline" class="detail-input">
+            <input matInput type="number" min="1" formControlName="default_exposure" (keyup.enter)="savePreference('default_exposure')">
+            @if (preferencesForm.get('default_exposure')?.hasError('min')) {
+              <mat-error>Must be at least 1 second.</mat-error>
+            }
+          </mat-form-field>
+          <button mat-icon-button color="primary" (click)="savePreference('default_exposure')" [disabled]="savingPreference" aria-label="Save default exposure">
+            <mat-icon>check</mat-icon>
+          </button>
+          <button mat-icon-button (click)="cancelEditPreference('default_exposure')" aria-label="Cancel">
+            <mat-icon>close</mat-icon>
+          </button>
+        } @else {
+          <div class="detail-value">{{ displayExposure(preferences?.default_exposure ?? null) }}</div>
+          <button mat-icon-button class="edit-btn" (click)="startEditPreference('default_exposure')" aria-label="Edit default exposure">
+            <mat-icon>edit</mat-icon>
+          </button>
+        }
+      </div>
+
+    </div>
   </div>
 </mat-card>

--- a/src/app/components/user/user.component.spec.ts
+++ b/src/app/components/user/user.component.spec.ts
@@ -202,6 +202,27 @@ describe('UserComponent', () => {
     expect(component.editingPreference).toBe('default_exposure');
   });
 
+  it('savePreference rejects a fractional exposure without calling the API', () => {
+    fixture.detectChanges();
+    component.startEditPreference('default_exposure');
+    component.preferencesForm.get('default_exposure')?.setValue(1.5);
+    component.savePreference('default_exposure');
+
+    expect(component.preferencesForm.get('default_exposure')?.hasError('integer')).toBe(true);
+    expect(userService.updatePreferences).not.toHaveBeenCalled();
+    expect(component.editingPreference).toBe('default_exposure');
+  });
+
+  it('shows a snackbar when preferences fail to load', () => {
+    userService.getPreferences.mockReturnValue(
+      throwError(() => new HttpErrorResponse({ status: 500 }))
+    );
+    fixture.detectChanges();
+
+    expect(snackBar.open).toHaveBeenCalledWith('Failed to load preferences.', 'Close', expect.anything());
+    expect(component.preferences).toBeNull();
+  });
+
   it('savePreference surfaces backend error messages and stays in edit mode', async () => {
     userService.updatePreferences.mockReturnValue(
       throwError(() => new HttpErrorResponse({ status: 404, error: { message: 'default_scope does not reference an existing telescope' } }))

--- a/src/app/components/user/user.component.spec.ts
+++ b/src/app/components/user/user.component.spec.ts
@@ -4,9 +4,11 @@ import { of, throwError } from 'rxjs';
 import { HttpErrorResponse } from '@angular/common/http';
 import { UserComponent } from './user.component';
 import { LoginService } from '../../services/login.service';
-import { UserService, UserProfile } from '../../services/user.service';
+import { UserService, UserProfile, UserPreferences } from '../../services/user.service';
 import { GravatarService } from '../../services/gravatar.service';
 import { TopBarService } from '../../services/top-bar.service';
+import { TelescopeService } from '../../services/telescope.service';
+import { FiltersService } from '../../services/filters.service';
 import { MatSnackBar } from '@angular/material/snack-bar';
 
 describe('UserComponent', () => {
@@ -16,9 +18,13 @@ describe('UserComponent', () => {
     getProfile: ReturnType<typeof vi.fn>;
     updateProfile: ReturnType<typeof vi.fn>;
     changePassword: ReturnType<typeof vi.fn>;
+    getPreferences: ReturnType<typeof vi.fn>;
+    updatePreferences: ReturnType<typeof vi.fn>;
   };
   let loginService: { getUser: ReturnType<typeof vi.fn>; loggedIn: ReturnType<typeof vi.fn> };
   let snackBar: { open: ReturnType<typeof vi.fn> };
+  let telescopeService: { getTelescopes: ReturnType<typeof vi.fn> };
+  let filtersService: { getFilters: ReturnType<typeof vi.fn> };
 
   const profile: UserProfile = {
     user_id: 1,
@@ -33,17 +39,34 @@ describe('UserComponent', () => {
     login_enabled: true
   };
 
+  const preferences: UserPreferences = {
+    default_exposure: 75,
+    default_filter: null,
+    default_scope: null,
+    task_binning: 2,
+    task_guiding: 1,
+    task_dither: null,
+    min_alt: 35,
+    limit_min_moon_dist: 0,
+    limit_max_sun_alt: -12,
+    limit_max_moon_phase: null
+  };
+
   beforeEach(async () => {
     userService = {
       getProfile: vi.fn().mockReturnValue(of(profile)),
       updateProfile: vi.fn().mockReturnValue(of(profile)),
-      changePassword: vi.fn().mockReturnValue(of({ status: true, msg: 'Password updated' }))
+      changePassword: vi.fn().mockReturnValue(of({ status: true, msg: 'Password updated' })),
+      getPreferences: vi.fn().mockReturnValue(of(preferences)),
+      updatePreferences: vi.fn().mockReturnValue(of(preferences))
     };
     loginService = {
       getUser: vi.fn().mockReturnValue({ user_id: 1, firstname: 'Ada', email: 'ada@example.com', permissions: 0 }),
       loggedIn: vi.fn()
     };
     snackBar = { open: vi.fn() };
+    telescopeService = { getTelescopes: vi.fn().mockReturnValue(of([])) };
+    filtersService = { getFilters: vi.fn().mockReturnValue(of([])) };
 
     await TestBed.configureTestingModule({
       imports: [NoopAnimationsModule, UserComponent],
@@ -51,6 +74,8 @@ describe('UserComponent', () => {
         { provide: UserService, useValue: userService },
         { provide: LoginService, useValue: loginService },
         { provide: MatSnackBar, useValue: snackBar },
+        { provide: TelescopeService, useValue: telescopeService },
+        { provide: FiltersService, useValue: filtersService },
         GravatarService,
         TopBarService
       ]
@@ -127,6 +152,70 @@ describe('UserComponent', () => {
 
     expect(userService.updateProfile).not.toHaveBeenCalled();
     expect(component.editingField).toBe('aavso_id');
+  });
+
+  it('loads preferences and shows them read-only, with no field in edit mode', () => {
+    fixture.detectChanges();
+    expect(userService.getPreferences).toHaveBeenCalled();
+    expect(component.editingPreference).toBeNull();
+    expect(component.displayExposure(component.preferences?.default_exposure ?? null)).toBe('75 s');
+    expect(component.displayScope(component.preferences?.default_scope ?? null)).toBe('—');
+  });
+
+  it('startEditPreference switches a preference field into edit mode', () => {
+    fixture.detectChanges();
+    component.startEditPreference('default_exposure');
+    expect(component.editingPreference).toBe('default_exposure');
+    expect(component.preferencesForm.get('default_exposure')?.value).toBe(75);
+  });
+
+  it('cancelEditPreference discards changes and exits edit mode', () => {
+    fixture.detectChanges();
+    component.startEditPreference('default_exposure');
+    component.preferencesForm.get('default_exposure')?.setValue(300);
+    component.cancelEditPreference('default_exposure');
+
+    expect(component.editingPreference).toBeNull();
+    expect(component.preferencesForm.get('default_exposure')?.value).toBe(75);
+    expect(userService.updatePreferences).not.toHaveBeenCalled();
+  });
+
+  it('savePreference updates only the edited field', async () => {
+    fixture.detectChanges();
+    component.startEditPreference('default_exposure');
+    component.preferencesForm.get('default_exposure')?.setValue(300);
+    component.savePreference('default_exposure');
+    await fixture.whenStable();
+
+    expect(userService.updatePreferences).toHaveBeenCalledWith({ default_exposure: 300 });
+    expect(component.editingPreference).toBeNull();
+    expect(snackBar.open).toHaveBeenCalledWith('Default exposure updated.', 'Close', expect.anything());
+  });
+
+  it('savePreference rejects an invalid value without calling the API', () => {
+    fixture.detectChanges();
+    component.startEditPreference('default_exposure');
+    component.preferencesForm.get('default_exposure')?.setValue(-5);
+    component.savePreference('default_exposure');
+
+    expect(userService.updatePreferences).not.toHaveBeenCalled();
+    expect(component.editingPreference).toBe('default_exposure');
+  });
+
+  it('savePreference surfaces backend error messages and stays in edit mode', async () => {
+    userService.updatePreferences.mockReturnValue(
+      throwError(() => new HttpErrorResponse({ status: 404, error: { message: 'default_scope does not reference an existing telescope' } }))
+    );
+    fixture.detectChanges();
+    component.startEditPreference('default_scope');
+    component.savePreference('default_scope');
+    await fixture.whenStable();
+
+    expect(snackBar.open).toHaveBeenCalledWith(
+      'default_scope does not reference an existing telescope', 'Close', expect.anything()
+    );
+    expect(component.savingPreference).toBe(false);
+    expect(component.editingPreference).toBe('default_scope');
   });
 
   it('the password form is collapsed by default and toggles open/closed', () => {

--- a/src/app/components/user/user.component.ts
+++ b/src/app/components/user/user.component.ts
@@ -12,16 +12,20 @@ import {
 import { MatCardModule } from '@angular/material/card';
 import { MatFormFieldModule } from '@angular/material/form-field';
 import { MatInputModule } from '@angular/material/input';
+import { MatSelectModule } from '@angular/material/select';
 import { MatButtonModule } from '@angular/material/button';
 import { MatButtonToggleModule } from '@angular/material/button-toggle';
 import { MatIconModule } from '@angular/material/icon';
 import { MatSnackBar } from '@angular/material/snack-bar';
 import { first } from 'rxjs/operators';
 import { LoginService } from '../../services/login.service';
-import { UserService, UserProfile, UserProfileUpdate } from '../../services/user.service';
+import { UserService, UserProfile, UserProfileUpdate, UserPreferences, UserPreferencesUpdate } from '../../services/user.service';
 import { GravatarService } from '../../services/gravatar.service';
 import { TopBarService } from '../../services/top-bar.service';
 import { ThemeService, ThemePreference } from '../../services/theme.service';
+import { TelescopeService, Telescope } from '../../services/telescope.service';
+import { FiltersService } from '../../services/filters.service';
+import { Filter } from '../../models/filter';
 import { User } from '../../models/user';
 
 type ProfileField = 'firstname' | 'lastname' | 'phone' | 'email' | 'aavso_id';
@@ -32,6 +36,14 @@ const PROFILE_FIELD_LABELS: Record<ProfileField, string> = {
   phone: 'Phone',
   email: 'Email',
   aavso_id: 'AAVSO observer ID'
+};
+
+type PreferenceField = 'default_scope' | 'default_filter' | 'default_exposure';
+
+const PREFERENCE_FIELD_LABELS: Record<PreferenceField, string> = {
+  default_scope: 'Default telescope',
+  default_filter: 'Default filter',
+  default_exposure: 'Default exposure'
 };
 
 /** Requires the confirm_password field to equal new_password. */
@@ -50,6 +62,7 @@ function passwordsMatchValidator(group: AbstractControl): ValidationErrors | nul
         MatCardModule,
         MatFormFieldModule,
         MatInputModule,
+        MatSelectModule,
         MatButtonModule,
         MatButtonToggleModule,
         MatIconModule
@@ -62,20 +75,29 @@ export class UserComponent implements OnInit {
     private userService = inject(UserService);
     private gravatarService = inject(GravatarService);
     private topBarService = inject(TopBarService);
+    private telescopeService = inject(TelescopeService);
+    private filtersService = inject(FiltersService);
     private formBuilder = inject(FormBuilder);
     private snackBar = inject(MatSnackBar);
     themeService = inject(ThemeService);
 
     readonly profileFields: ProfileField[] = ['firstname', 'lastname', 'phone', 'email', 'aavso_id'];
     readonly fieldLabels = PROFILE_FIELD_LABELS;
+    readonly preferenceFieldLabels = PREFERENCE_FIELD_LABELS;
 
     user: User | null = null;
     profile: UserProfile | null = null;
+    preferences: UserPreferences | null = null;
+    telescopes: Telescope[] = [];
+    filters: Filter[] = [];
     avatarUrl = '';
 
     /** Field currently switched into edit mode, or null when the panel just shows details. */
     editingField: ProfileField | null = null;
     savingField = false;
+
+    editingPreference: PreferenceField | null = null;
+    savingPreference = false;
 
     showPasswordForm = false;
     changingPassword = false;
@@ -98,6 +120,12 @@ export class UserComponent implements OnInit {
         },
         { validators: passwordsMatchValidator }
     );
+
+    preferencesForm: FormGroup = this.formBuilder.group({
+        default_scope: [null],
+        default_filter: [null],
+        default_exposure: [null, [Validators.min(1)]]
+    });
 
     ngOnInit(): void {
         this.topBarService.updateState({
@@ -125,6 +153,27 @@ export class UserComponent implements OnInit {
                 // Keep showing the cached login response; /users/me is unreachable.
             }
         });
+
+        this.userService.getPreferences().pipe(first()).subscribe({
+            next: preferences => this.applyPreferences(preferences),
+            error: () => {
+                // Preferences panel just stays empty if /users/me/preferences is unreachable.
+            }
+        });
+
+        this.telescopeService.getTelescopes().pipe(first()).subscribe({
+            next: telescopes => this.telescopes = telescopes,
+            error: () => {
+                // Dropdown stays empty; existing default_scope value (if any) still displays via displayScope/displayFilter.
+            }
+        });
+
+        this.filtersService.getFilters().pipe(first()).subscribe({
+            next: filters => this.filters = filters,
+            error: () => {
+                // Dropdown stays empty.
+            }
+        });
     }
 
     private applyProfile(profile: UserProfile): void {
@@ -137,6 +186,15 @@ export class UserComponent implements OnInit {
             aavso_id: profile.aavso_id ?? ''
         });
         this.updateAvatar(profile.email, profile.user_id);
+    }
+
+    private applyPreferences(preferences: UserPreferences): void {
+        this.preferences = preferences;
+        this.preferencesForm.patchValue({
+            default_scope: preferences.default_scope,
+            default_filter: preferences.default_filter,
+            default_exposure: preferences.default_exposure
+        });
     }
 
     private updateAvatar(email: string | null | undefined, userId: number | undefined | null): void {
@@ -197,6 +255,57 @@ export class UserComponent implements OnInit {
             email: profile.email ?? undefined,
             aavso_id: profile.aavso_id ?? undefined,
             permissions: stored.permissions != null ? String(stored.permissions) : undefined
+        });
+    }
+
+    displayScope(scopeId: number | null): string {
+        if (scopeId == null) {
+            return '—';
+        }
+        return this.telescopes.find(t => t.scope_id === scopeId)?.name ?? `#${scopeId}`;
+    }
+
+    displayFilter(filterId: number | null): string {
+        if (filterId == null) {
+            return '—';
+        }
+        return this.filters.find(f => f.filter_id === filterId)?.short_name ?? `#${filterId}`;
+    }
+
+    displayExposure(exposure: number | null): string {
+        return exposure == null ? '—' : `${exposure} s`;
+    }
+
+    startEditPreference(field: PreferenceField): void {
+        this.preferencesForm.get(field)?.setValue(this.preferences?.[field] ?? null);
+        this.editingPreference = field;
+    }
+
+    cancelEditPreference(field: PreferenceField): void {
+        this.preferencesForm.get(field)?.setValue(this.preferences?.[field] ?? null);
+        this.preferencesForm.get(field)?.markAsUntouched();
+        this.editingPreference = null;
+    }
+
+    savePreference(field: PreferenceField): void {
+        const control = this.preferencesForm.get(field);
+        if (!control || control.invalid) {
+            control?.markAsTouched();
+            return;
+        }
+        this.savingPreference = true;
+        const body: UserPreferencesUpdate = { [field]: control.value };
+        this.userService.updatePreferences(body).pipe(first()).subscribe({
+            next: preferences => {
+                this.savingPreference = false;
+                this.applyPreferences(preferences);
+                this.editingPreference = null;
+                this.showMessage(`${this.preferenceFieldLabels[field]} updated.`);
+            },
+            error: (err: HttpErrorResponse) => {
+                this.savingPreference = false;
+                this.showMessage(err?.error?.message || 'Failed to update preferences.');
+            }
         });
     }
 

--- a/src/app/components/user/user.component.ts
+++ b/src/app/components/user/user.component.ts
@@ -39,6 +39,12 @@ const PROFILE_FIELD_LABELS: Record<ProfileField, string> = {
 };
 
 type PreferenceField = 'default_scope' | 'default_filter' | 'default_exposure';
+type PreferenceFieldKind = 'scope' | 'filter' | 'exposure';
+
+interface PreferenceFieldConfig {
+  field: PreferenceField;
+  kind: PreferenceFieldKind;
+}
 
 const PREFERENCE_FIELD_LABELS: Record<PreferenceField, string> = {
   default_scope: 'Default telescope',
@@ -46,11 +52,35 @@ const PREFERENCE_FIELD_LABELS: Record<PreferenceField, string> = {
   default_exposure: 'Default exposure'
 };
 
+const PREFERENCE_FIELDS: PreferenceFieldConfig[] = [
+  { field: 'default_scope', kind: 'scope' },
+  { field: 'default_filter', kind: 'filter' },
+  { field: 'default_exposure', kind: 'exposure' }
+];
+
 /** Requires the confirm_password field to equal new_password. */
 function passwordsMatchValidator(group: AbstractControl): ValidationErrors | null {
   const newPassword = group.get('new_password')?.value;
   const confirm = group.get('confirm_password')?.value;
   return newPassword && confirm && newPassword !== confirm ? { passwordMismatch: true } : null;
+}
+
+/** Allows null/empty (cleared preference); otherwise requires an integer >= min. */
+function optionalIntegerMinValidator(min: number) {
+  return (control: AbstractControl): ValidationErrors | null => {
+    const raw = control.value;
+    if (raw == null || raw === '') {
+      return null;
+    }
+    const n = typeof raw === 'number' ? raw : Number(raw);
+    if (!Number.isFinite(n) || !Number.isInteger(n)) {
+      return { integer: true };
+    }
+    if (n < min) {
+      return { min: { min, actual: n } };
+    }
+    return null;
+  };
 }
 
 @Component({
@@ -83,6 +113,7 @@ export class UserComponent implements OnInit {
 
     readonly profileFields: ProfileField[] = ['firstname', 'lastname', 'phone', 'email', 'aavso_id'];
     readonly fieldLabels = PROFILE_FIELD_LABELS;
+    readonly preferenceFields = PREFERENCE_FIELDS;
     readonly preferenceFieldLabels = PREFERENCE_FIELD_LABELS;
 
     user: User | null = null;
@@ -124,7 +155,7 @@ export class UserComponent implements OnInit {
     preferencesForm: FormGroup = this.formBuilder.group({
         default_scope: [null],
         default_filter: [null],
-        default_exposure: [null, [Validators.min(1)]]
+        default_exposure: [null, [optionalIntegerMinValidator(1)]]
     });
 
     ngOnInit(): void {
@@ -157,7 +188,7 @@ export class UserComponent implements OnInit {
         this.userService.getPreferences().pipe(first()).subscribe({
             next: preferences => this.applyPreferences(preferences),
             error: () => {
-                // Preferences panel just stays empty if /users/me/preferences is unreachable.
+                this.showMessage('Failed to load preferences.');
             }
         });
 
@@ -276,6 +307,18 @@ export class UserComponent implements OnInit {
         return exposure == null ? '—' : `${exposure} s`;
     }
 
+    displayPreference(field: PreferenceField): string {
+        const value = this.preferences?.[field] ?? null;
+        switch (field) {
+            case 'default_scope':
+                return this.displayScope(value);
+            case 'default_filter':
+                return this.displayFilter(value);
+            case 'default_exposure':
+                return this.displayExposure(value);
+        }
+    }
+
     startEditPreference(field: PreferenceField): void {
         this.preferencesForm.get(field)?.setValue(this.preferences?.[field] ?? null);
         this.editingPreference = field;
@@ -294,7 +337,11 @@ export class UserComponent implements OnInit {
             return;
         }
         this.savingPreference = true;
-        const body: UserPreferencesUpdate = { [field]: control.value };
+        let value = control.value;
+        if (field === 'default_exposure' && (value === '' || value == null)) {
+            value = null;
+        }
+        const body: UserPreferencesUpdate = { [field]: value };
         this.userService.updatePreferences(body).pipe(first()).subscribe({
             next: preferences => {
                 this.savingPreference = false;

--- a/src/app/services/user.service.spec.ts
+++ b/src/app/services/user.service.spec.ts
@@ -78,4 +78,51 @@ describe('UserService', () => {
     expect(req.request.body).toEqual({ current_password: 'old-pw', new_password: 'new-password-123' });
     req.flush({ status: true, msg: 'Password updated' });
   });
+
+  it('getPreferences fetches the current user preferences', () => {
+    service.getPreferences().subscribe(prefs => {
+      expect(prefs.default_exposure).toBe(75);
+      expect(prefs.default_scope).toBeNull();
+    });
+
+    const req = httpMock.expectOne(`${Hevelius.apiUrl}/users/me/preferences`);
+    expect(req.request.method).toBe('GET');
+    req.flush({
+      default_exposure: 75,
+      default_filter: null,
+      default_scope: null,
+      task_binning: 2,
+      task_guiding: 1,
+      task_dither: null,
+      min_alt: 35,
+      limit_min_moon_dist: 0,
+      limit_max_sun_alt: -12,
+      limit_max_moon_phase: null
+    });
+  });
+
+  it('updatePreferences PATCHes only the provided preference fields', () => {
+    service
+      .updatePreferences({ default_exposure: 300, default_scope: null })
+      .subscribe(prefs => {
+        expect(prefs.default_exposure).toBe(300);
+        expect(prefs.default_scope).toBeNull();
+      });
+
+    const req = httpMock.expectOne(`${Hevelius.apiUrl}/users/me/preferences`);
+    expect(req.request.method).toBe('PATCH');
+    expect(req.request.body).toEqual({ default_exposure: 300, default_scope: null });
+    req.flush({
+      default_exposure: 300,
+      default_filter: null,
+      default_scope: null,
+      task_binning: 2,
+      task_guiding: 1,
+      task_dither: null,
+      min_alt: 35,
+      limit_min_moon_dist: 0,
+      limit_max_sun_alt: -12,
+      limit_max_moon_phase: null
+    });
+  });
 });

--- a/src/app/services/user.service.ts
+++ b/src/app/services/user.service.ts
@@ -32,6 +32,34 @@ export interface PasswordChangeRequest {
   new_password: string;
 }
 
+// See UsersMePreferencesResource in hevelius-backend's
+// hevelius/api/routes/auth_users.py for the source of truth.
+export interface UserPreferences {
+  default_exposure: number | null;
+  default_filter: number | null;
+  default_scope: number | null;
+  task_binning: number | null;
+  task_guiding: number | null;
+  task_dither: number | null;
+  min_alt: number | null;
+  limit_min_moon_dist: number | null;
+  limit_max_sun_alt: number | null;
+  limit_max_moon_phase: number | null;
+}
+
+export interface UserPreferencesUpdate {
+  default_exposure?: number | null;
+  default_filter?: number | null;
+  default_scope?: number | null;
+  task_binning?: number | null;
+  task_guiding?: number | null;
+  task_dither?: number | null;
+  min_alt?: number | null;
+  limit_min_moon_dist?: number | null;
+  limit_max_sun_alt?: number | null;
+  limit_max_moon_phase?: number | null;
+}
+
 @Injectable({
   providedIn: 'root'
 })
@@ -49,5 +77,13 @@ export class UserService {
 
   changePassword(body: PasswordChangeRequest): Observable<StatusMsgResponse> {
     return this.http.post<StatusMsgResponse>(`${this.apiUrl}/password`, body);
+  }
+
+  getPreferences(): Observable<UserPreferences> {
+    return this.http.get<UserPreferences>(`${this.apiUrl}/preferences`);
+  }
+
+  updatePreferences(body: UserPreferencesUpdate): Observable<UserPreferences> {
+    return this.http.patch<UserPreferences>(`${this.apiUrl}/preferences`, body);
   }
 }


### PR DESCRIPTION
## Summary
- Depends on backend PR borowka-obs/hevelius-backend#109, which adds `GET/PATCH /users/me/preferences`.
- `UserService` gains `getPreferences()`/`updatePreferences()` plus `UserPreferences`/`UserPreferencesUpdate` interfaces mirroring the backend schema.
- The User page's existing "Preferences" card gets three new inline-editable rows — Default telescope, Default filter, Default exposure — using the same edit/save/cancel pattern as the existing profile fields (firstname, phone, etc). Telescope and filter options are populated from the existing `/scopes` and `/filters` endpoints.

## Test plan
- [x] `ng test` — all 232 tests pass, including 7 new tests covering preference loading, edit/save/cancel, validation, and backend error surfacing.
- [x] `ng build` succeeds.
- [x] Manually exercised in a real browser against a locally running backend + Postgres: logged in, opened the User page, confirmed the Preferences card renders saved values (telescope name / filter short name / exposure), opened the telescope dropdown, selected a different telescope, saved, and confirmed the "Default telescope updated." confirmation and persisted value.


---
_Generated by [Claude Code](https://claude.ai/code/session_01HGfGcTUzvYUmqG372DUx4i)_