### PR TITLE
Rewrite the Night Plan page against the new scheduler API

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -45,6 +45,8 @@ This project has an **Angular 20** frontend (this repo) and a **Flask** backend 
 - Auth: `POST /login`, `GET /version` (and token usage via interceptor).
 - Tasks: `GET/POST /tasks`, `POST /task-add`, `POST /task-update`, `GET /task-get`.
 - Catalogs: `GET /catalogs/search`, `GET /catalogs/list`. List accepts optional query params: `page`, `per_page`, `sort_by`, `sort_order`, `catalog`, `name`, `constellation` (IAU 3-letter abbreviation, e.g. Cyg, Sgr). Backend must filter by these when provided.
-- Other: `GET /scopes` (telescopes), `POST /night-plan`.
+- Other: `GET /scopes` (telescopes), `GET /night-plan` (query params: `scope_id`
+  required, `date` = evening date `YYYY-MM-DD` (defaults to the backend's current
+  night), `explain` = include excluded items and their reasons).
 
 When adding a new endpoint, add the route and DTOs on the backend, then add or update the Angular model and a service method that calls `Hevelius.apiUrl + '/your-path'` with the same contract.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Hevelius Web Interface Changelog
 
+unreleased
+
+- **Night Plan** page rewritten against the new scheduler API
+  (`GET /api/night-plan`) and added to the main menu. You now pick the
+  telescope (defaulted from your `default_scope` preference, but always
+  overridable) and the night (defaults to tonight), and each entry — tasks and
+  projects alike — shows its maximum altitude, Moon separation, and best time
+  to observe. An **Explain** toggle lists the candidates the scheduler left out
+  together with the constraints they failed, which answers "why isn't my target
+  showing up?".
+
 0.6.0 (2026-07-25)
 
 - Added self-service account management: the **User** page (`/user`) now

--- a/README.md
+++ b/README.md
@@ -29,7 +29,10 @@ As of July 2026, the following features are available:
   sky proximity; Catalogs page (`/catalogs`) lists installed catalogs
 - Sky Map (`/sky-map`): Aladin Lite all-sky view of active projects with FOV
   overlays; project detail includes a DSS sky view with the project FOV
-- Night plan (experimental); About panel
+- Night plan (`/night-plan`): per-telescope, per-night plan of tasks and
+  projects with max altitude, Moon separation, and best observing time, plus an
+  "explain" mode listing excluded candidates and the constraints they failed
+- About panel
 
 The interface is responsive (phone-friendly layouts for Objects, Catalogs, and
 projects). It was tested on desktop (Ubuntu, Windows) and mobile (iPhone).

--- a/src/app/components/layout/layout.component.html
+++ b/src/app/components/layout/layout.component.html
@@ -26,6 +26,10 @@
       <mat-icon>list</mat-icon>
       <span>Tasks</span>
     </button>
+    <button mat-menu-item routerLink="/night-plan">
+      <mat-icon>bedtime</mat-icon>
+      <span>Night Plan</span>
+    </button>
     <button mat-menu-item routerLink="/scopes">
       <mat-icon>visibility</mat-icon>
       <span>Telescopes</span>

--- a/src/app/components/night-plan/night-plan.component.css
+++ b/src/app/components/night-plan/night-plan.component.css
@@ -1,11 +1,112 @@
+.container {
+  padding: 16px;
+}
+
 table {
   width: 100%;
 }
 
-.spacer {
-  flex: 1 1 auto;
+.table-container {
+  overflow-x: auto;
 }
 
-mat-toolbar {
-  margin-bottom: 20px;
+.plan-controls {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 1rem;
+  margin-bottom: 1rem;
+}
+
+.scope-field {
+  min-width: 200px;
+}
+
+.date-field {
+  min-width: 180px;
+}
+
+.plan-loading {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  margin: 1rem 0;
+}
+
+.plan-error {
+  color: var(--mat-sys-error);
+}
+
+.plan-summary,
+.plan-empty {
+  margin: 0 0 1rem;
+}
+
+.kind-icon {
+  font-size: 20px;
+  width: 20px;
+  height: 20px;
+  vertical-align: middle;
+}
+
+.excluded-section {
+  margin-top: 1.5rem;
+  background: var(--mat-sys-surface-container-low);
+  padding: 1rem;
+  border-radius: 4px;
+}
+
+.excluded-section h3 {
+  margin-top: 0;
+}
+
+.excluded-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.excluded-item {
+  margin-bottom: 0.75rem;
+}
+
+.excluded-name {
+  font-weight: 500;
+}
+
+.excluded-kind {
+  font-weight: 400;
+  opacity: 0.7;
+  margin-left: 0.25rem;
+}
+
+.excluded-reasons {
+  margin: 0.25rem 0 0;
+  padding-left: 1.5rem;
+  opacity: 0.85;
+}
+
+@media (max-width: 640px) {
+  .container {
+    padding: 8px;
+  }
+
+  .plan-controls {
+    gap: 0.5rem;
+  }
+
+  .scope-field,
+  .date-field {
+    flex: 1 1 100%;
+    min-width: 0;
+  }
+
+  table {
+    font-size: 0.82rem;
+  }
+
+  .mat-mdc-header-cell,
+  .mat-mdc-cell {
+    padding: 4px 6px !important;
+  }
 }

--- a/src/app/components/night-plan/night-plan.component.html
+++ b/src/app/components/night-plan/night-plan.component.html
@@ -1,39 +1,154 @@
-<table mat-table [dataSource]="dataSource">
-  <ng-container matColumnDef="task_id">
-    <th mat-header-cell *matHeaderCellDef>No.</th>
-    <td mat-cell *matCellDef="let task">{{ task.task_id }}</td>
-  </ng-container>
+<div class="container">
+  <div class="plan-controls">
+    <mat-form-field subscriptSizing="dynamic" class="scope-field">
+      <mat-label>Telescope</mat-label>
+      <mat-select [formControl]="scopeControl" (selectionChange)="onScopeChange($event.value)">
+        @for (scope of activeTelescopes; track scope.scope_id) {
+          <mat-option [value]="scope.scope_id">{{ scope.name }}</mat-option>
+        } @empty {
+          <mat-option [value]="null" disabled>No active telescopes configured</mat-option>
+        }
+      </mat-select>
+    </mat-form-field>
 
-  <ng-container matColumnDef="user_id">
-    <th mat-header-cell *matHeaderCellDef>Owner</th>
-    <td mat-cell *matCellDef="let task">{{ task.aavso_id }}</td>
-  </ng-container>
+    <mat-form-field subscriptSizing="dynamic" class="date-field">
+      <mat-label>Night of</mat-label>
+      <input matInput [matDatepicker]="nightPicker" [formControl]="dateControl"
+             (dateChange)="onDateChange($event.value)">
+      <mat-datepicker-toggle matIconSuffix [for]="nightPicker"></mat-datepicker-toggle>
+      <mat-datepicker #nightPicker></mat-datepicker>
+    </mat-form-field>
 
-  <ng-container matColumnDef="state">
-    <th mat-header-cell *matHeaderCellDef>State</th>
-    <td mat-cell *matCellDef="let task">{{ task.state }}</td>
-  </ng-container>
+    <button type="button" mat-button (click)="resetToTonight()">Tonight</button>
 
-  <ng-container matColumnDef="object">
-    <th mat-header-cell *matHeaderCellDef>Target</th>
-    <td mat-cell *matCellDef="let task">{{ task.object }}</td>
-  </ng-container>
+    <mat-slide-toggle
+      [formControl]="explainControl"
+      (change)="onExplainChange($event.checked)"
+      matTooltip="Also list the tasks and projects that were left out, and why">
+      Explain
+    </mat-slide-toggle>
+  </div>
 
-  <ng-container matColumnDef="ra">
-    <th mat-header-cell *matHeaderCellDef>RA</th>
-    <td mat-cell *matCellDef="let task">{{ formatRA(task.ra) }}</td>
-  </ng-container>
+  @if (loading) {
+    <div class="plan-loading">
+      <mat-spinner diameter="24"></mat-spinner>
+      <span>Computing the plan…</span>
+    </div>
+  } @else if (error) {
+    <p class="plan-error" role="alert">{{ error }}</p>
+  } @else if (plan) {
+    <p class="plan-summary">
+      {{ items.length }} item{{ items.length === 1 ? '' : 's' }} for
+      <strong>{{ plan.scope_name || scopeControl.value }}</strong>
+      on the night of <strong>{{ plan.date }}</strong>.
+      @if (plan.night_start && plan.night_end) {
+        Night runs {{ formatTimeLabel(plan.night_start) }}–{{ formatTimeLabel(plan.night_end) }} UTC.
+      }
+      @if (plan.moon_phase !== null && plan.moon_phase !== undefined) {
+        Moon {{ (plan.moon_phase * 100).toFixed(0) }}% illuminated.
+      }
+    </p>
 
-  <ng-container matColumnDef="decl">
-    <th mat-header-cell *matHeaderCellDef>Dec</th>
-    <td mat-cell *matCellDef="let task">{{ formatDec(task.decl) }}</td>
-  </ng-container>
+    @if (items.length === 0) {
+      <p class="plan-empty">
+        Nothing is observable on this night for this telescope.
+        @if (!explainControl.value) {
+          Turn on <strong>Explain</strong> to see why each candidate was excluded.
+        }
+      </p>
+    } @else {
+      <div class="table-container">
+        <table mat-table [dataSource]="items" [trackBy]="trackItem" class="mat-elevation-z8">
+          <ng-container matColumnDef="kind">
+            <th mat-header-cell *matHeaderCellDef>Type</th>
+            <td mat-cell *matCellDef="let item">
+              <mat-icon
+                [matTooltip]="item.kind === 'project' ? 'Project' : 'Task'"
+                class="kind-icon">{{ item.kind === 'project' ? 'folder' : 'list' }}</mat-icon>
+            </td>
+          </ng-container>
 
-  <ng-container matColumnDef="exposure">
-    <th mat-header-cell *matHeaderCellDef>Exposure</th>
-    <td mat-cell *matCellDef="let task">{{ task.exposure }}</td>
-  </ng-container>
+          <ng-container matColumnDef="object">
+            <th mat-header-cell *matHeaderCellDef>Target</th>
+            <td mat-cell *matCellDef="let item">
+              @let link = getItemLink(item);
+              @if (link) {
+                <a [routerLink]="link">{{ item.object }}</a>
+              } @else {
+                {{ item.object }}
+              }
+            </td>
+          </ng-container>
 
-  <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>
-  <tr mat-row *matRowDef="let row; columns: displayedColumns;"></tr>
-</table>
+          <ng-container matColumnDef="ra">
+            <th mat-header-cell *matHeaderCellDef>RA</th>
+            <td mat-cell *matCellDef="let item">{{ formatRA(item.ra) }}</td>
+          </ng-container>
+
+          <ng-container matColumnDef="decl">
+            <th mat-header-cell *matHeaderCellDef>Dec</th>
+            <td mat-cell *matCellDef="let item">{{ formatDec(item.decl) }}</td>
+          </ng-container>
+
+          <ng-container matColumnDef="max_altitude">
+            <th mat-header-cell *matHeaderCellDef>Max alt</th>
+            <td mat-cell *matCellDef="let item">{{ formatDegrees(item.max_altitude_deg) }}</td>
+          </ng-container>
+
+          <ng-container matColumnDef="moon_separation">
+            <th mat-header-cell *matHeaderCellDef>Moon sep</th>
+            <td mat-cell *matCellDef="let item">{{ formatDegrees(item.moon_separation_deg) }}</td>
+          </ng-container>
+
+          <ng-container matColumnDef="best_time">
+            <th mat-header-cell *matHeaderCellDef>Best time (UTC)</th>
+            <td mat-cell *matCellDef="let item">{{ formatTimeLabel(item.best_time) }}</td>
+          </ng-container>
+
+          <ng-container matColumnDef="exposure">
+            <th mat-header-cell *matHeaderCellDef>Exposure</th>
+            <td mat-cell *matCellDef="let item">{{ item.exposure ?? '—' }}</td>
+          </ng-container>
+
+          <ng-container matColumnDef="state">
+            <th mat-header-cell *matHeaderCellDef>State</th>
+            <td mat-cell *matCellDef="let item">{{ getStateLabel(item.state) }}</td>
+          </ng-container>
+
+          <tr mat-header-row *matHeaderRowDef="displayedColumns; sticky: true"></tr>
+          <tr mat-row *matRowDef="let row; columns: displayedColumns;"></tr>
+        </table>
+      </div>
+    }
+
+    @if (explainControl.value) {
+      <div class="excluded-section">
+        <h3>Excluded ({{ excluded.length }})</h3>
+        @if (excluded.length === 0) {
+          <p class="plan-empty">Nothing was excluded — every candidate made it into the plan.</p>
+        } @else {
+          <ul class="excluded-list">
+            @for (item of excluded; track trackItem($index, item)) {
+              <li class="excluded-item">
+                <span class="excluded-name">
+                  @let link = getItemLink(item);
+                  @if (link) {
+                    <a [routerLink]="link">{{ item.object }}</a>
+                  } @else {
+                    {{ item.object }}
+                  }
+                  <span class="excluded-kind">({{ item.kind }})</span>
+                </span>
+                <ul class="excluded-reasons">
+                  @for (reason of item.reasons; track reason) {
+                    <li>{{ reason }}</li>
+                  }
+                </ul>
+              </li>
+            }
+          </ul>
+        }
+      </div>
+    }
+  }
+</div>

--- a/src/app/components/night-plan/night-plan.component.html
+++ b/src/app/components/night-plan/night-plan.component.html
@@ -40,12 +40,12 @@
     <p class="plan-summary">
       {{ items.length }} item{{ items.length === 1 ? '' : 's' }} for
       <strong>{{ plan.scope_name || scopeControl.value }}</strong>
-      on the night of <strong>{{ plan.date }}</strong>.
-      @if (plan.night_start && plan.night_end) {
-        Night runs {{ formatTimeLabel(plan.night_start) }}–{{ formatTimeLabel(plan.night_end) }} UTC.
+      on the night of <strong>{{ plan.night_date }}</strong>.
+      @if (plan.night_start_utc && plan.night_end_utc) {
+        Night runs {{ formatTimeLabel(plan.night_start_utc) }}–{{ formatTimeLabel(plan.night_end_utc) }} UTC.
       }
-      @if (plan.moon_phase !== null && plan.moon_phase !== undefined) {
-        Moon {{ (plan.moon_phase * 100).toFixed(0) }}% illuminated.
+      @if (plan.moon_illumination_pct !== null && plan.moon_illumination_pct !== undefined) {
+        Moon {{ plan.moon_illumination_pct.toFixed(0) }}% illuminated.
       }
     </p>
 
@@ -73,46 +73,46 @@
             <td mat-cell *matCellDef="let item">
               @let link = getItemLink(item);
               @if (link) {
-                <a [routerLink]="link">{{ item.object }}</a>
+                <a [routerLink]="link">{{ getItemName(item) }}</a>
               } @else {
-                {{ item.object }}
+                {{ getItemName(item) }}
               }
             </td>
           </ng-container>
 
           <ng-container matColumnDef="ra">
             <th mat-header-cell *matHeaderCellDef>RA</th>
-            <td mat-cell *matCellDef="let item">{{ formatRA(item.ra) }}</td>
+            <td mat-cell *matCellDef="let item">{{ formatRA(getItemRa(item)) }}</td>
           </ng-container>
 
           <ng-container matColumnDef="decl">
             <th mat-header-cell *matHeaderCellDef>Dec</th>
-            <td mat-cell *matCellDef="let item">{{ formatDec(item.decl) }}</td>
+            <td mat-cell *matCellDef="let item">{{ formatDec(getItemDec(item)) }}</td>
           </ng-container>
 
           <ng-container matColumnDef="max_altitude">
-            <th mat-header-cell *matHeaderCellDef>Max alt</th>
-            <td mat-cell *matCellDef="let item">{{ formatDegrees(item.max_altitude_deg) }}</td>
+            <th mat-header-cell *matHeaderCellDef>Altitude</th>
+            <td mat-cell *matCellDef="let item">{{ formatDegrees(item.visibility?.altitude_deg) }}</td>
           </ng-container>
 
           <ng-container matColumnDef="moon_separation">
             <th mat-header-cell *matHeaderCellDef>Moon sep</th>
-            <td mat-cell *matCellDef="let item">{{ formatDegrees(item.moon_separation_deg) }}</td>
+            <td mat-cell *matCellDef="let item">{{ formatDegrees(item.visibility?.moon_separation_deg) }}</td>
           </ng-container>
 
           <ng-container matColumnDef="best_time">
             <th mat-header-cell *matHeaderCellDef>Best time (UTC)</th>
-            <td mat-cell *matCellDef="let item">{{ formatTimeLabel(item.best_time) }}</td>
+            <td mat-cell *matCellDef="let item">{{ formatTimeLabel(item.visibility?.check_time_utc) }}</td>
           </ng-container>
 
           <ng-container matColumnDef="exposure">
             <th mat-header-cell *matHeaderCellDef>Exposure</th>
-            <td mat-cell *matCellDef="let item">{{ item.exposure ?? '—' }}</td>
+            <td mat-cell *matCellDef="let item">{{ getItemExposure(item) }}</td>
           </ng-container>
 
           <ng-container matColumnDef="state">
             <th mat-header-cell *matHeaderCellDef>State</th>
-            <td mat-cell *matCellDef="let item">{{ getStateLabel(item.state) }}</td>
+            <td mat-cell *matCellDef="let item">{{ getStateLabel(getItemState(item)) }}</td>
           </ng-container>
 
           <tr mat-header-row *matHeaderRowDef="displayedColumns; sticky: true"></tr>
@@ -133,16 +133,14 @@
                 <span class="excluded-name">
                   @let link = getItemLink(item);
                   @if (link) {
-                    <a [routerLink]="link">{{ item.object }}</a>
+                    <a [routerLink]="link">{{ getItemName(item) }}</a>
                   } @else {
-                    {{ item.object }}
+                    {{ getItemName(item) }}
                   }
                   <span class="excluded-kind">({{ item.kind }})</span>
                 </span>
                 <ul class="excluded-reasons">
-                  @for (reason of item.reasons; track reason) {
-                    <li>{{ reason }}</li>
-                  }
+                  <li>{{ formatExclusionReason(item.reason) }}</li>
                 </ul>
               </li>
             }

--- a/src/app/components/night-plan/night-plan.component.spec.ts
+++ b/src/app/components/night-plan/night-plan.component.spec.ts
@@ -1,77 +1,220 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { provideNoopAnimations } from '@angular/platform-browser/animations';
+import { provideRouter } from '@angular/router';
+import { of, throwError } from 'rxjs';
+
 import { NightPlanComponent } from './night-plan.component';
 import { NightPlanService } from '../../services/night-plan.service';
+import { TelescopeService, Telescope } from '../../services/telescope.service';
+import { UserService, UserPreferences } from '../../services/user.service';
 import { CoordsFormatterService } from '../../services/coords-formatter.service';
-import { MatTableModule } from '@angular/material/table';
-import { BehaviorSubject } from 'rxjs';
-import { Task } from '../../models/task';
+import { NightPlanResponse } from '../../models/night-plan';
+
+function makeTelescope(scopeId: number, name: string, active = true): Telescope {
+  return {
+    scope_id: scopeId,
+    name,
+    descr: '',
+    min_dec: -90,
+    max_dec: 90,
+    focal: null,
+    aperture: null,
+    lon: null,
+    lat: null,
+    alt: null,
+    sensor: null,
+    active,
+    default_rotation: null
+  };
+}
+
+const PLAN: NightPlanResponse = {
+  status: true,
+  scope_id: 7,
+  scope_name: 'Scope 7',
+  date: '2026-08-06',
+  night_start: '2026-08-06 20:11:00',
+  night_end: '2026-08-07 03:02:00',
+  moon_phase: 0.42,
+  items: [
+    {
+      kind: 'task',
+      task_id: 1,
+      object: 'M31',
+      ra: 0.712,
+      decl: 41.27,
+      exposure: 300,
+      state: 1,
+      max_altitude_deg: 62.3,
+      best_time: '2026-08-07 01:20:00',
+      moon_separation_deg: 88.1
+    },
+    {
+      kind: 'project',
+      project_id: 4,
+      object: 'Veil Nebula',
+      ra: 20.85,
+      decl: 31.0,
+      max_altitude_deg: 71.0,
+      best_time: '2026-08-07 00:05:00',
+      moon_separation_deg: 61.4
+    }
+  ],
+  excluded: [
+    {
+      kind: 'task',
+      task_id: 9,
+      object: 'M42',
+      reasons: ['max altitude 4° below min_alt 30°']
+    }
+  ]
+};
 
 describe('NightPlanComponent', () => {
   let component: NightPlanComponent;
   let fixture: ComponentFixture<NightPlanComponent>;
-  let nightPlanService: {
-    loadNightPlan: ReturnType<typeof vi.fn>;
-    connect: ReturnType<typeof vi.fn>;
-    disconnect: ReturnType<typeof vi.fn>;
-  };
-  let tasksSubject: BehaviorSubject<Task[]>;
+  let nightPlanService: { getNightPlan: ReturnType<typeof vi.fn> };
+  let telescopeService: { getTelescopes: ReturnType<typeof vi.fn> };
+  let userService: { getPreferences: ReturnType<typeof vi.fn> };
 
-  beforeEach(async () => {
-    tasksSubject = new BehaviorSubject<Task[]>([]);
-    nightPlanService = {
-      loadNightPlan: vi.fn(),
-      connect: vi.fn().mockReturnValue(tasksSubject.asObservable()),
-      disconnect: vi.fn(),
-    };
+  const preferences = { default_scope: 7 } as UserPreferences;
 
+  async function setup(): Promise<void> {
     await TestBed.configureTestingModule({
-      imports: [ MatTableModule,
-        NightPlanComponent
-       ],
+      imports: [NightPlanComponent],
       providers: [
+        provideNoopAnimations(),
+        provideRouter([]),
         { provide: NightPlanService, useValue: nightPlanService },
+        { provide: TelescopeService, useValue: telescopeService },
+        { provide: UserService, useValue: userService },
         CoordsFormatterService
       ]
     }).compileComponents();
-  });
 
-  beforeEach(() => {
     fixture = TestBed.createComponent(NightPlanComponent);
     component = fixture.componentInstance;
     fixture.detectChanges();
+  }
+
+  beforeEach(() => {
+    nightPlanService = { getNightPlan: vi.fn().mockReturnValue(of(PLAN)) };
+    telescopeService = {
+      getTelescopes: vi.fn().mockReturnValue(of([
+        makeTelescope(3, 'Scope 3'),
+        makeTelescope(7, 'Scope 7'),
+        makeTelescope(8, 'Retired scope', false)
+      ]))
+    };
+    userService = { getPreferences: vi.fn().mockReturnValue(of(preferences)) };
   });
 
-  it('should create', () => {
+  it('should create', async () => {
+    await setup();
     expect(component).toBeTruthy();
   });
 
-  it('should load night plan on init', () => {
-    expect(nightPlanService.loadNightPlan).toHaveBeenCalled();
+  it('should default the telescope to the user preference and load the plan', async () => {
+    await setup();
+
+    expect(component.scopeControl.value).toBe(7);
+    expect(nightPlanService.getNightPlan).toHaveBeenCalledTimes(1);
+    const params = nightPlanService.getNightPlan.mock.calls[0][0];
+    expect(params.scope_id).toBe(7);
+    expect(params.explain).toBe(false);
+    expect(params.date).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+    expect(component.items.length).toBe(2);
   });
 
-  it('should update task count when tasks change', () => {
-    const mockTasks = [
-      { task_id: 1, object: 'Test Object 1' },
-      { task_id: 2, object: 'Test Object 2' }
-    ] as Task[];
-
-    tasksSubject.next(mockTasks);
-    fixture.detectChanges();
-
-    expect(component.taskCount).toBe(2);
+  it('should only offer active telescopes', async () => {
+    await setup();
+    expect(component.activeTelescopes.map(t => t.scope_id)).toEqual([3, 7]);
   });
 
-  it('should format RA correctly', () => {
-    const coordFormatter = TestBed.inject(CoordsFormatterService);
-    const testRA = 12.345;
-    const formattedRA = component.formatRA(testRA);
-    expect(formattedRA).toBe(coordFormatter.formatRA(testRA));
+  it('should fall back to the first active telescope when the preference is not usable', async () => {
+    userService.getPreferences.mockReturnValue(of({ default_scope: 42 } as UserPreferences));
+    await setup();
+
+    expect(component.scopeControl.value).toBe(3);
+    expect(nightPlanService.getNightPlan.mock.calls[0][0].scope_id).toBe(3);
   });
 
-  it('should format Dec correctly', () => {
-    const coordFormatter = TestBed.inject(CoordsFormatterService);
-    const testDec = 45.678;
-    const formattedDec = component.formatDec(testDec);
-    expect(formattedDec).toBe(coordFormatter.formatDec(testDec));
+  it('should still work when the preferences call fails', async () => {
+    userService.getPreferences.mockReturnValue(throwError(() => new Error('nope')));
+    await setup();
+
+    expect(component.scopeControl.value).toBe(3);
+    expect(nightPlanService.getNightPlan).toHaveBeenCalled();
+  });
+
+  it('should report when there is no active telescope to plan for', async () => {
+    telescopeService.getTelescopes.mockReturnValue(of([makeTelescope(8, 'Retired', false)]));
+    await setup();
+
+    expect(component.scopeControl.value).toBeNull();
+    expect(component.error).toBeTruthy();
+    expect(nightPlanService.getNightPlan).not.toHaveBeenCalled();
+  });
+
+  it('should reload with the new telescope on change', async () => {
+    await setup();
+    component.onScopeChange(3);
+
+    expect(nightPlanService.getNightPlan).toHaveBeenCalledTimes(2);
+    expect(nightPlanService.getNightPlan.mock.calls[1][0].scope_id).toBe(3);
+  });
+
+  it('should reload with the picked night', async () => {
+    await setup();
+    component.onDateChange(new Date(2026, 0, 15));
+
+    expect(nightPlanService.getNightPlan.mock.calls[1][0].date).toBe('2026-01-15');
+  });
+
+  it('should request the excluded items when explain is turned on', async () => {
+    await setup();
+    component.onExplainChange(true);
+
+    expect(nightPlanService.getNightPlan.mock.calls[1][0].explain).toBe(true);
+    expect(component.excluded.length).toBe(1);
+    expect(component.excluded[0].reasons[0]).toContain('min_alt');
+  });
+
+  it('should show an error message when the plan cannot be loaded', async () => {
+    await setup();
+    nightPlanService.getNightPlan.mockReturnValue(
+      throwError(() => ({ error: { msg: 'scope_id is required' } }))
+    );
+    component.loadNightPlan();
+
+    expect(component.error).toBe('scope_id is required');
+    expect(component.items).toEqual([]);
+    expect(component.excluded).toEqual([]);
+  });
+
+  it('should format visibility metadata for display', async () => {
+    await setup();
+
+    expect(component.formatDegrees(62.34)).toBe('62.3°');
+    expect(component.formatDegrees(null)).toBe('—');
+    expect(component.formatTimeLabel('2026-08-07 01:20:00')).toBe('01:20');
+    expect(component.formatTimeLabel(null)).toBe('—');
+  });
+
+  it('should link projects to their detail page and leave tasks unlinked', async () => {
+    await setup();
+
+    expect(component.getItemLink(PLAN.items[1])).toEqual(['/projects', 4]);
+    expect(component.getItemLink(PLAN.items[0])).toBeNull();
+  });
+
+  it('should format coordinates through the shared formatter', async () => {
+    await setup();
+    const formatter = TestBed.inject(CoordsFormatterService);
+
+    expect(component.formatRA(12.345)).toBe(formatter.formatRA(12.345));
+    expect(component.formatDec(45.678)).toBe(formatter.formatDec(45.678));
+    expect(component.formatRA(null)).toBe('');
+    expect(component.formatDec(null)).toBe('');
   });
 });

--- a/src/app/components/night-plan/night-plan.component.spec.ts
+++ b/src/app/components/night-plan/night-plan.component.spec.ts
@@ -1,7 +1,7 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { provideNoopAnimations } from '@angular/platform-browser/animations';
 import { provideRouter } from '@angular/router';
-import { of, throwError } from 'rxjs';
+import { Subject, of, throwError } from 'rxjs';
 
 import { NightPlanComponent } from './night-plan.component';
 import { NightPlanService } from '../../services/night-plan.service';
@@ -144,8 +144,11 @@ describe('NightPlanComponent', () => {
     const params = nightPlanService.getNightPlan.mock.calls[0][0];
     expect(params.scope_id).toBe(7);
     expect(params.explain).toBe(false);
-    expect(params.date).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+    // Omit date so the backend picks the telescope's current observing night.
+    expect(params.date).toBeUndefined();
     expect(component.items.length).toBe(2);
+    // Date picker reflects the night the backend returned.
+    expect(component.dateControl.value).toEqual(new Date(2026, 7, 6));
   });
 
   it('should only offer active telescopes', async () => {
@@ -174,7 +177,30 @@ describe('NightPlanComponent', () => {
     await setup();
 
     expect(component.scopeControl.value).toBeNull();
-    expect(component.error).toBeTruthy();
+    expect(component.error).toBe('No active telescope available to plan for.');
+    expect(nightPlanService.getNightPlan).not.toHaveBeenCalled();
+  });
+
+  it('should still plan with default_scope when the telescope list fails', async () => {
+    telescopeService.getTelescopes.mockReturnValue(throwError(() => new Error('scopes down')));
+    await setup();
+
+    expect(component.scopeControl.value).toBe(7);
+    expect(nightPlanService.getNightPlan).toHaveBeenCalledTimes(1);
+    expect(nightPlanService.getNightPlan.mock.calls[0][0].scope_id).toBe(7);
+    expect(component.error).toBeNull();
+    expect(component.activeTelescopes.map(t => t.scope_id)).toEqual([7]);
+    // Placeholder name replaced from the plan response.
+    expect(component.activeTelescopes[0].name).toBe('Scope 7');
+  });
+
+  it('should report a telescope load failure when there is no default_scope', async () => {
+    telescopeService.getTelescopes.mockReturnValue(throwError(() => new Error('scopes down')));
+    userService.getPreferences.mockReturnValue(of({ default_scope: null } as UserPreferences));
+    await setup();
+
+    expect(component.scopeControl.value).toBeNull();
+    expect(component.error).toBe('Could not load telescopes.');
     expect(nightPlanService.getNightPlan).not.toHaveBeenCalled();
   });
 
@@ -191,6 +217,47 @@ describe('NightPlanComponent', () => {
     component.onDateChange(new Date(2026, 0, 15));
 
     expect(nightPlanService.getNightPlan.mock.calls[1][0].date).toBe('2026-01-15');
+  });
+
+  it('should omit date again when Tonight is clicked', async () => {
+    await setup();
+    component.onDateChange(new Date(2026, 0, 15));
+    component.resetToTonight();
+
+    const lastParams = nightPlanService.getNightPlan.mock.calls.at(-1)[0];
+    expect(lastParams.date).toBeUndefined();
+  });
+
+  it('should ignore a stale plan response when a newer request finishes first', async () => {
+    const slowPlan$ = new Subject<NightPlanResponse>();
+    const fastPlan: NightPlanResponse = {
+      ...PLAN,
+      scope_id: 3,
+      scope_name: 'Scope 3',
+      items: []
+    };
+
+    nightPlanService.getNightPlan
+      .mockReturnValueOnce(of(PLAN))
+      .mockReturnValueOnce(slowPlan$.asObservable())
+      .mockReturnValueOnce(of(fastPlan));
+
+    await setup();
+    expect(component.items.length).toBe(2);
+
+    component.onScopeChange(7); // starts slow request
+    component.onScopeChange(3); // cancels it; fast response wins
+
+    expect(component.scopeControl.value).toBe(3);
+    expect(component.items).toEqual([]);
+    expect(component.plan?.scope_id).toBe(3);
+
+    // Late response from the cancelled request must not overwrite state.
+    slowPlan$.next(PLAN);
+    slowPlan$.complete();
+
+    expect(component.plan?.scope_id).toBe(3);
+    expect(component.items).toEqual([]);
   });
 
   it('should request the excluded items when explain is turned on', async () => {

--- a/src/app/components/night-plan/night-plan.component.spec.ts
+++ b/src/app/components/night-plan/night-plan.component.spec.ts
@@ -9,6 +9,8 @@ import { TelescopeService, Telescope } from '../../services/telescope.service';
 import { UserService, UserPreferences } from '../../services/user.service';
 import { CoordsFormatterService } from '../../services/coords-formatter.service';
 import { NightPlanResponse } from '../../models/night-plan';
+import { Task } from '../../models/task';
+import { Project } from '../../models/project';
 
 function makeTelescope(scopeId: number, name: string, active = true): Telescope {
   return {
@@ -29,43 +31,63 @@ function makeTelescope(scopeId: number, name: string, active = true): Telescope 
 }
 
 const PLAN: NightPlanResponse = {
-  status: true,
   scope_id: 7,
   scope_name: 'Scope 7',
-  date: '2026-08-06',
-  night_start: '2026-08-06 20:11:00',
-  night_end: '2026-08-07 03:02:00',
-  moon_phase: 0.42,
+  night_date: '2026-08-06',
+  night_start_utc: '2026-08-06T20:11:00Z',
+  night_end_utc: '2026-08-07T03:02:00Z',
+  moon_illumination_pct: 42,
   items: [
     {
       kind: 'task',
-      task_id: 1,
-      object: 'M31',
-      ra: 0.712,
-      decl: 41.27,
-      exposure: 300,
-      state: 1,
-      max_altitude_deg: 62.3,
-      best_time: '2026-08-07 01:20:00',
-      moon_separation_deg: 88.1
+      task: {
+        task_id: 1,
+        user_id: 3,
+        aavso_id: '',
+        object: 'M31',
+        ra: 0.712,
+        decl: 41.27,
+        exposure: 300,
+        state: 1
+      } as Task,
+      visibility: {
+        altitude_deg: 62.3,
+        check_time_utc: '2026-08-07T01:20:00Z',
+        moon_separation_deg: 88.1
+      }
     },
     {
       kind: 'project',
-      project_id: 4,
-      object: 'Veil Nebula',
-      ra: 20.85,
-      decl: 31.0,
-      max_altitude_deg: 71.0,
-      best_time: '2026-08-07 00:05:00',
-      moon_separation_deg: 61.4
+      project: {
+        project_id: 4,
+        name: 'Veil Nebula',
+        scope_id: 7,
+        ra: 20.85,
+        decl: 31.0,
+        active: true,
+        subframes: [
+          {
+            id: 1,
+            project_id: 4,
+            filter_id: 5,
+            exposure_time: 300,
+            active: true
+          }
+        ]
+      } as Project,
+      visibility: {
+        altitude_deg: 71.0,
+        check_time_utc: '2026-08-07T00:05:00Z',
+        moon_separation_deg: 61.4
+      }
     }
   ],
   excluded: [
     {
       kind: 'task',
       task_id: 9,
-      object: 'M42',
-      reasons: ['max altitude 4° below min_alt 30°']
+      name: 'M42',
+      reason: 'below_min_altitude'
     }
   ]
 };
@@ -177,7 +199,7 @@ describe('NightPlanComponent', () => {
 
     expect(nightPlanService.getNightPlan.mock.calls[1][0].explain).toBe(true);
     expect(component.excluded.length).toBe(1);
-    expect(component.excluded[0].reasons[0]).toContain('min_alt');
+    expect(component.formatExclusionReason(component.excluded[0].reason)).toContain('altitude');
   });
 
   it('should show an error message when the plan cannot be loaded', async () => {
@@ -197,7 +219,7 @@ describe('NightPlanComponent', () => {
 
     expect(component.formatDegrees(62.34)).toBe('62.3°');
     expect(component.formatDegrees(null)).toBe('—');
-    expect(component.formatTimeLabel('2026-08-07 01:20:00')).toBe('01:20');
+    expect(component.formatTimeLabel('2026-08-07T01:20:00Z')).toBe('01:20');
     expect(component.formatTimeLabel(null)).toBe('—');
   });
 
@@ -206,6 +228,19 @@ describe('NightPlanComponent', () => {
 
     expect(component.getItemLink(PLAN.items[1])).toEqual(['/projects', 4]);
     expect(component.getItemLink(PLAN.items[0])).toBeNull();
+  });
+
+  it('should read nested task/project fields for the table', async () => {
+    await setup();
+
+    expect(component.getItemName(PLAN.items[0])).toBe('M31');
+    expect(component.getItemName(PLAN.items[1])).toBe('Veil Nebula');
+    expect(component.getItemRa(PLAN.items[0])).toBe(0.712);
+    expect(component.getItemDec(PLAN.items[1])).toBe(31.0);
+    expect(component.getItemExposure(PLAN.items[0])).toBe(300);
+    expect(component.getItemExposure(PLAN.items[1])).toBe(300);
+    expect(component.getItemState(PLAN.items[0])).toBe(1);
+    expect(component.getItemState(PLAN.items[1])).toBeNull();
   });
 
   it('should format coordinates through the shared formatter', async () => {

--- a/src/app/components/night-plan/night-plan.component.ts
+++ b/src/app/components/night-plan/night-plan.component.ts
@@ -1,8 +1,8 @@
 import { Component, OnInit, OnDestroy, HostListener, inject } from '@angular/core';
 import { FormControl, ReactiveFormsModule } from '@angular/forms';
 import { RouterModule } from '@angular/router';
-import { forkJoin, of } from 'rxjs';
-import { catchError } from 'rxjs/operators';
+import { EMPTY, Subject, forkJoin, of } from 'rxjs';
+import { catchError, map, switchMap, takeUntil } from 'rxjs/operators';
 
 import { MatTableModule } from '@angular/material/table';
 import { MatFormFieldModule } from '@angular/material/form-field';
@@ -25,6 +25,7 @@ import { TopBarService } from '../../services/top-bar.service';
 import {
     NightPlanExcludedItem,
     NightPlanItem,
+    NightPlanParams,
     NightPlanResponse
 } from '../../models/night-plan';
 
@@ -83,6 +84,15 @@ export class NightPlanComponent implements OnInit, OnDestroy {
     loading = false;
     error: string | null = null;
 
+    /**
+     * When set, sent as the `date` query param. When null, the param is omitted
+     * so the backend picks the observing night in progress at the telescope.
+     */
+    private explicitNightDate: string | null = null;
+
+    private readonly loadTrigger$ = new Subject<void>();
+    private readonly destroy$ = new Subject<void>();
+
     private readonly MOBILE_BREAKPOINT = 640;
     isMobile = typeof window !== 'undefined' && window.innerWidth <= this.MOBILE_BREAKPOINT;
 
@@ -117,40 +127,90 @@ export class NightPlanComponent implements OnInit, OnDestroy {
             this.topBarService.updateState({ title: 'Night plan' });
         });
 
+        this.loadTrigger$.pipe(
+            switchMap(() => this.fetchNightPlan()),
+            takeUntil(this.destroy$)
+        ).subscribe(response => {
+            this.loading = false;
+            this.plan = response;
+            this.items = response?.items ?? [];
+            this.excluded = response?.excluded ?? [];
+            this.syncDateControlFromPlan(response);
+            this.ensureScopeLabel(response);
+            this.updateTitle();
+        });
+
         this.loading = true;
         // Telescope list and the user's default_scope are both needed before the
         // first plan request; a missing preferences call must not block the page.
         forkJoin({
             telescopes: this.telescopeService.getTelescopes().pipe(
-                catchError(() => of([] as Telescope[]))
+                map(list => ({ ok: true as const, list })),
+                catchError(() => of({ ok: false as const, list: [] as Telescope[] }))
             ),
             preferences: this.userService.getPreferences().pipe(
                 catchError(() => of(null as UserPreferences | null))
             )
-        }).subscribe(({ telescopes, preferences }) => {
-            this.telescopes = telescopes;
+        }).pipe(
+            takeUntil(this.destroy$)
+        ).subscribe(({ telescopes, preferences }) => {
+            this.telescopes = telescopes.list;
             this.loading = false;
 
-            const scopeId = this.pickInitialScope(preferences?.default_scope ?? null);
+            const defaultScope = preferences?.default_scope ?? null;
+            const scopeId = this.pickInitialScope(defaultScope, telescopes.ok);
             if (scopeId === null) {
-                this.error = 'No active telescope available to plan for.';
+                this.error = telescopes.ok
+                    ? 'No active telescope available to plan for.'
+                    : 'Could not load telescopes.';
                 return;
             }
+
+            if (!telescopes.ok) {
+                // List failed, but default_scope is still usable for the plan request.
+                this.telescopes = [this.makeScopePlaceholder(scopeId)];
+            }
+
             this.scopeControl.setValue(scopeId);
             this.loadNightPlan();
         });
     }
 
     /**
-     * The user's `default_scope` wins when it names an active telescope;
-     * otherwise fall back to the first active one so the page shows something.
+     * Prefer the user's `default_scope` when it names an active telescope;
+     * otherwise the first active scope. If the telescope list itself failed,
+     * still trust a saved `default_scope` so the page can load a plan.
      */
-    private pickInitialScope(defaultScope: number | null): number | null {
+    private pickInitialScope(defaultScope: number | null, telescopesLoaded: boolean): number | null {
         const active = this.activeTelescopes;
         if (defaultScope !== null && active.some(t => t.scope_id === defaultScope)) {
             return defaultScope;
         }
-        return active.length > 0 ? active[0].scope_id : null;
+        if (active.length > 0) {
+            return active[0].scope_id;
+        }
+        if (!telescopesLoaded && defaultScope !== null) {
+            return defaultScope;
+        }
+        return null;
+    }
+
+    private makeScopePlaceholder(scopeId: number): Telescope {
+        return {
+            scope_id: scopeId,
+            name: `Scope ${scopeId}`,
+            descr: '',
+            min_dec: -90,
+            max_dec: 90,
+            focal: null,
+            aperture: null,
+            lon: null,
+            lat: null,
+            alt: null,
+            sensor: null,
+            active: true,
+            default_rotation: null
+        };
     }
 
     onScopeChange(scopeId: number | null): void {
@@ -159,7 +219,9 @@ export class NightPlanComponent implements OnInit, OnDestroy {
     }
 
     onDateChange(newDate: Date | null): void {
-        this.dateControl.setValue(newDate ?? new Date());
+        const date = newDate ?? new Date();
+        this.dateControl.setValue(date);
+        this.explicitNightDate = this.formatDateForApi(date);
         this.loadNightPlan();
     }
 
@@ -168,42 +230,66 @@ export class NightPlanComponent implements OnInit, OnDestroy {
         this.loadNightPlan();
     }
 
-    /** Jump to tonight; the backend decides which night "tonight" is. */
+    /** Jump to tonight; omit `date` so the backend picks the current night. */
     resetToTonight(): void {
-        this.dateControl.setValue(new Date());
+        this.explicitNightDate = null;
         this.loadNightPlan();
     }
 
     loadNightPlan(): void {
+        if (this.scopeControl.value === null || this.scopeControl.value === undefined) {
+            return;
+        }
+        this.loadTrigger$.next();
+    }
+
+    private fetchNightPlan() {
         const scopeId = this.scopeControl.value;
         if (scopeId === null || scopeId === undefined) {
-            return;
+            return EMPTY;
         }
 
         this.loading = true;
         this.error = null;
 
-        this.nightPlanService.getNightPlan({
+        const params: NightPlanParams = {
             scope_id: scopeId,
-            date: this.formatDateForApi(this.dateControl.value ?? new Date()),
             explain: this.explainControl.value
-        }).subscribe({
-            next: response => {
-                this.loading = false;
-                this.plan = response;
-                this.items = response?.items ?? [];
-                this.excluded = response?.excluded ?? [];
-                this.updateTitle();
-            },
-            error: err => {
+        };
+        if (this.explicitNightDate) {
+            params.date = this.explicitNightDate;
+        }
+
+        return this.nightPlanService.getNightPlan(params).pipe(
+            catchError(err => {
                 this.loading = false;
                 this.plan = null;
                 this.items = [];
                 this.excluded = [];
                 this.error = err?.error?.msg || err?.error?.message || 'Could not load the night plan.';
                 this.updateTitle();
-            }
-        });
+                return EMPTY;
+            })
+        );
+    }
+
+    /** Keep the date picker in sync when the backend chose the night. */
+    private syncDateControlFromPlan(response: NightPlanResponse): void {
+        if (this.explicitNightDate || !response?.night_date) {
+            return;
+        }
+        this.dateControl.setValue(this.parseNightDate(response.night_date), { emitEvent: false });
+    }
+
+    /** Replace a placeholder scope label with the name from the plan response. */
+    private ensureScopeLabel(response: NightPlanResponse): void {
+        if (!response?.scope_name) {
+            return;
+        }
+        const scope = this.telescopes.find(t => t.scope_id === response.scope_id);
+        if (scope && scope.name === `Scope ${response.scope_id}`) {
+            scope.name = response.scope_name;
+        }
     }
 
     private updateTitle(): void {
@@ -217,6 +303,12 @@ export class NightPlanComponent implements OnInit, OnDestroy {
         const month = String(d.getMonth() + 1).padStart(2, '0');
         const day = String(d.getDate()).padStart(2, '0');
         return `${year}-${month}-${day}`;
+    }
+
+    /** Parse YYYY-MM-DD as a local calendar date (avoids UTC midnight shifts). */
+    private parseNightDate(yyyyMmDd: string): Date {
+        const [year, month, day] = yyyyMmDd.split('-').map(Number);
+        return new Date(year, month - 1, day);
     }
 
     /** Target name: task object or project name. */
@@ -319,6 +411,9 @@ export class NightPlanComponent implements OnInit, OnDestroy {
     };
 
     ngOnDestroy(): void {
+        this.destroy$.next();
+        this.destroy$.complete();
+        this.loadTrigger$.complete();
         this.topBarService.resetState();
     }
 }

--- a/src/app/components/night-plan/night-plan.component.ts
+++ b/src/app/components/night-plan/night-plan.component.ts
@@ -28,6 +28,20 @@ import {
     NightPlanResponse
 } from '../../models/night-plan';
 
+/** Human-readable labels for scheduler exclusion reason codes. */
+const EXCLUSION_REASON_LABELS: Record<string, string> = {
+    wrong_state: 'Wrong state',
+    outside_date_window: 'Outside date window',
+    outside_mount_dec_range: 'Outside mount Dec range',
+    filter_not_on_scope: 'Filter not on this telescope',
+    already_complete: 'Already complete',
+    missing_coordinates: 'Missing coordinates',
+    below_min_altitude: 'Below minimum altitude',
+    sun_too_high: 'Sun too high',
+    moon_too_close: 'Moon too close',
+    moon_phase_too_bright: 'Moon phase too bright'
+};
+
 @Component({
     selector: 'app-night-plan',
     templateUrl: './night-plan.component.html',
@@ -47,7 +61,7 @@ import {
     MatIconModule,
     MatProgressSpinnerModule,
     MatTooltipModule
-]
+    ]
 })
 export class NightPlanComponent implements OnInit, OnDestroy {
     private nightPlanService = inject(NightPlanService);
@@ -205,6 +219,39 @@ export class NightPlanComponent implements OnInit, OnDestroy {
         return `${year}-${month}-${day}`;
     }
 
+    /** Target name: task object or project name. */
+    getItemName(item: NightPlanItem | NightPlanExcludedItem): string {
+        if ('name' in item && item.name) {
+            return item.name;
+        }
+        const planItem = item as NightPlanItem;
+        return planItem.task?.object || planItem.project?.name || '—';
+    }
+
+    getItemRa(item: NightPlanItem): number | null | undefined {
+        return item.task?.ra ?? item.project?.ra;
+    }
+
+    getItemDec(item: NightPlanItem): number | null | undefined {
+        return item.task?.decl ?? item.project?.decl;
+    }
+
+    getItemExposure(item: NightPlanItem): number | string {
+        if (item.kind === 'task') {
+            return item.task?.exposure ?? '—';
+        }
+        const pending = item.project?.subframes;
+        if (!pending?.length) {
+            return '—';
+        }
+        // Show the first pending subframe's exposure; projects can have several.
+        return pending[0].exposure_time ?? '—';
+    }
+
+    getItemState(item: NightPlanItem): number | null | undefined {
+        return item.kind === 'task' ? item.task?.state : null;
+    }
+
     formatRA(ra: number | null | undefined): string {
         if (ra === null || ra === undefined) {
             return '';
@@ -227,7 +274,7 @@ export class NightPlanComponent implements OnInit, OnDestroy {
         return `${value.toFixed(1)}°`;
     }
 
-    /** HH:MM extracted from a "YYYY-MM-DD HH:MM:SS.sss" UTC timestamp. */
+    /** HH:MM extracted from a UTC timestamp (ISO-8601 or space-separated). */
     formatTimeLabel(time: string | null | undefined): string {
         if (!time) {
             return '—';
@@ -243,16 +290,33 @@ export class NightPlanComponent implements OnInit, OnDestroy {
         return this.taskStates.getState(state);
     }
 
-    /** Router link to the task's project or the project itself; null for tasks. */
-    getItemLink(item: NightPlanItem | NightPlanExcludedItem): unknown[] | null {
-        if (item.kind === 'project' && item.project_id != null) {
-            return ['/projects', item.project_id];
+    formatExclusionReason(reason: string | null | undefined): string {
+        if (!reason) {
+            return '—';
         }
-        return null;
+        return EXCLUSION_REASON_LABELS[reason] ?? reason.replace(/_/g, ' ');
     }
 
-    trackItem = (_index: number, item: NightPlanItem | NightPlanExcludedItem): string =>
-        `${item.kind}-${item.task_id ?? item.project_id ?? item.object}`;
+    /** Router link to the project's detail page; null for tasks. */
+    getItemLink(item: NightPlanItem | NightPlanExcludedItem): unknown[] | null {
+        if (item.kind !== 'project') {
+            return null;
+        }
+        const projectId = (item as NightPlanItem).project?.project_id
+            ?? (item as NightPlanExcludedItem).project_id;
+        return projectId != null ? ['/projects', projectId] : null;
+    }
+
+    trackItem = (_index: number, item: NightPlanItem | NightPlanExcludedItem): string => {
+        const planItem = item as NightPlanItem;
+        const excluded = item as NightPlanExcludedItem;
+        const id = planItem.task?.task_id
+            ?? planItem.project?.project_id
+            ?? excluded.task_id
+            ?? excluded.project_id
+            ?? this.getItemName(item);
+        return `${item.kind}-${id}`;
+    };
 
     ngOnDestroy(): void {
         this.topBarService.resetState();

--- a/src/app/components/night-plan/night-plan.component.ts
+++ b/src/app/components/night-plan/night-plan.component.ts
@@ -1,10 +1,32 @@
-import { Component, OnInit, inject } from '@angular/core';
-import { NightPlanService } from '../../services/night-plan.service';
-import { CoordsFormatterService } from '../../services/coords-formatter.service';
+import { Component, OnInit, OnDestroy, HostListener, inject } from '@angular/core';
+import { FormControl, ReactiveFormsModule } from '@angular/forms';
+import { RouterModule } from '@angular/router';
+import { forkJoin, of } from 'rxjs';
+import { catchError } from 'rxjs/operators';
 
 import { MatTableModule } from '@angular/material/table';
-import { MatSortModule } from '@angular/material/sort';
-import { MatPaginatorModule } from '@angular/material/paginator';
+import { MatFormFieldModule } from '@angular/material/form-field';
+import { MatInputModule } from '@angular/material/input';
+import { MatSelectModule } from '@angular/material/select';
+import { MatDatepickerModule } from '@angular/material/datepicker';
+import { MatNativeDateModule } from '@angular/material/core';
+import { MatSlideToggleModule } from '@angular/material/slide-toggle';
+import { MatButtonModule } from '@angular/material/button';
+import { MatIconModule } from '@angular/material/icon';
+import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
+import { MatTooltipModule } from '@angular/material/tooltip';
+
+import { NightPlanService } from '../../services/night-plan.service';
+import { CoordsFormatterService } from '../../services/coords-formatter.service';
+import { TaskStatesService } from '../../services/task-states.service';
+import { TelescopeService, Telescope } from '../../services/telescope.service';
+import { UserService, UserPreferences } from '../../services/user.service';
+import { TopBarService } from '../../services/top-bar.service';
+import {
+    NightPlanExcludedItem,
+    NightPlanItem,
+    NightPlanResponse
+} from '../../models/night-plan';
 
 @Component({
     selector: 'app-night-plan',
@@ -12,41 +34,227 @@ import { MatPaginatorModule } from '@angular/material/paginator';
     styleUrls: ['./night-plan.component.css'],
     standalone: true,
     imports: [
+    ReactiveFormsModule,
+    RouterModule,
     MatTableModule,
-    MatSortModule,
-    MatPaginatorModule
+    MatFormFieldModule,
+    MatInputModule,
+    MatSelectModule,
+    MatDatepickerModule,
+    MatNativeDateModule,
+    MatSlideToggleModule,
+    MatButtonModule,
+    MatIconModule,
+    MatProgressSpinnerModule,
+    MatTooltipModule
 ]
 })
-export class NightPlanComponent implements OnInit {
+export class NightPlanComponent implements OnInit, OnDestroy {
     private nightPlanService = inject(NightPlanService);
     private coordFormatter = inject(CoordsFormatterService);
+    private taskStates = inject(TaskStatesService);
+    private telescopeService = inject(TelescopeService);
+    private userService = inject(UserService);
+    private topBarService = inject(TopBarService);
 
-    dataSource: NightPlanService;
-    displayedColumns: string[] = ['task_id', 'user_id', 'state', 'object', 'ra', 'decl', 'exposure'];
-    taskCount = 0;
+    scopeControl = new FormControl<number | null>(null);
+    dateControl = new FormControl<Date>(new Date());
+    explainControl = new FormControl<boolean>(false, { nonNullable: true });
 
-    constructor() {
-        const nightPlanService = this.nightPlanService;
+    telescopes: Telescope[] = [];
+    plan: NightPlanResponse | null = null;
+    items: NightPlanItem[] = [];
+    excluded: NightPlanExcludedItem[] = [];
 
-        this.dataSource = nightPlanService;
+    loading = false;
+    error: string | null = null;
+
+    private readonly MOBILE_BREAKPOINT = 640;
+    isMobile = typeof window !== 'undefined' && window.innerWidth <= this.MOBILE_BREAKPOINT;
+
+    @HostListener('window:resize')
+    onResize(): void {
+        this.isMobile = window.innerWidth <= this.MOBILE_BREAKPOINT;
     }
 
-    ngOnInit() {
-        this.loadNightPlan();
-        this.dataSource.connect().subscribe(tasks => {
-            this.taskCount = tasks.length;
+    get displayedColumns(): string[] {
+        if (this.isMobile) {
+            return ['kind', 'object', 'max_altitude', 'best_time'];
+        }
+        return [
+            'kind',
+            'object',
+            'ra',
+            'decl',
+            'max_altitude',
+            'moon_separation',
+            'best_time',
+            'exposure',
+            'state'
+        ];
+    }
+
+    get activeTelescopes(): Telescope[] {
+        return this.telescopes.filter(t => t.active);
+    }
+
+    ngOnInit(): void {
+        setTimeout(() => {
+            this.topBarService.updateState({ title: 'Night plan' });
+        });
+
+        this.loading = true;
+        // Telescope list and the user's default_scope are both needed before the
+        // first plan request; a missing preferences call must not block the page.
+        forkJoin({
+            telescopes: this.telescopeService.getTelescopes().pipe(
+                catchError(() => of([] as Telescope[]))
+            ),
+            preferences: this.userService.getPreferences().pipe(
+                catchError(() => of(null as UserPreferences | null))
+            )
+        }).subscribe(({ telescopes, preferences }) => {
+            this.telescopes = telescopes;
+            this.loading = false;
+
+            const scopeId = this.pickInitialScope(preferences?.default_scope ?? null);
+            if (scopeId === null) {
+                this.error = 'No active telescope available to plan for.';
+                return;
+            }
+            this.scopeControl.setValue(scopeId);
+            this.loadNightPlan();
         });
     }
 
-    loadNightPlan() {
-        this.dataSource.loadNightPlan();
+    /**
+     * The user's `default_scope` wins when it names an active telescope;
+     * otherwise fall back to the first active one so the page shows something.
+     */
+    private pickInitialScope(defaultScope: number | null): number | null {
+        const active = this.activeTelescopes;
+        if (defaultScope !== null && active.some(t => t.scope_id === defaultScope)) {
+            return defaultScope;
+        }
+        return active.length > 0 ? active[0].scope_id : null;
     }
 
-    formatRA(ra: number): string {
+    onScopeChange(scopeId: number | null): void {
+        this.scopeControl.setValue(scopeId);
+        this.loadNightPlan();
+    }
+
+    onDateChange(newDate: Date | null): void {
+        this.dateControl.setValue(newDate ?? new Date());
+        this.loadNightPlan();
+    }
+
+    onExplainChange(explain: boolean): void {
+        this.explainControl.setValue(explain);
+        this.loadNightPlan();
+    }
+
+    /** Jump to tonight; the backend decides which night "tonight" is. */
+    resetToTonight(): void {
+        this.dateControl.setValue(new Date());
+        this.loadNightPlan();
+    }
+
+    loadNightPlan(): void {
+        const scopeId = this.scopeControl.value;
+        if (scopeId === null || scopeId === undefined) {
+            return;
+        }
+
+        this.loading = true;
+        this.error = null;
+
+        this.nightPlanService.getNightPlan({
+            scope_id: scopeId,
+            date: this.formatDateForApi(this.dateControl.value ?? new Date()),
+            explain: this.explainControl.value
+        }).subscribe({
+            next: response => {
+                this.loading = false;
+                this.plan = response;
+                this.items = response?.items ?? [];
+                this.excluded = response?.excluded ?? [];
+                this.updateTitle();
+            },
+            error: err => {
+                this.loading = false;
+                this.plan = null;
+                this.items = [];
+                this.excluded = [];
+                this.error = err?.error?.msg || err?.error?.message || 'Could not load the night plan.';
+                this.updateTitle();
+            }
+        });
+    }
+
+    private updateTitle(): void {
+        this.topBarService.updateState({
+            title: `Night plan: ${this.items.length} items`
+        });
+    }
+
+    private formatDateForApi(d: Date): string {
+        const year = d.getFullYear();
+        const month = String(d.getMonth() + 1).padStart(2, '0');
+        const day = String(d.getDate()).padStart(2, '0');
+        return `${year}-${month}-${day}`;
+    }
+
+    formatRA(ra: number | null | undefined): string {
+        if (ra === null || ra === undefined) {
+            return '';
+        }
         return this.coordFormatter.formatRA(ra);
     }
 
-    formatDec(dec: number): string {
+    formatDec(dec: number | null | undefined): string {
+        if (dec === null || dec === undefined) {
+            return '';
+        }
         return this.coordFormatter.formatDec(dec);
+    }
+
+    /** Degrees with one decimal, or an em dash when the backend had nothing to say. */
+    formatDegrees(value: number | null | undefined): string {
+        if (value === null || value === undefined) {
+            return '—';
+        }
+        return `${value.toFixed(1)}°`;
+    }
+
+    /** HH:MM extracted from a "YYYY-MM-DD HH:MM:SS.sss" UTC timestamp. */
+    formatTimeLabel(time: string | null | undefined): string {
+        if (!time) {
+            return '—';
+        }
+        const match = time.match(/(\d{2}):(\d{2})/);
+        return match ? `${match[1]}:${match[2]}` : time;
+    }
+
+    getStateLabel(state: number | null | undefined): string {
+        if (state === null || state === undefined) {
+            return '—';
+        }
+        return this.taskStates.getState(state);
+    }
+
+    /** Router link to the task's project or the project itself; null for tasks. */
+    getItemLink(item: NightPlanItem | NightPlanExcludedItem): unknown[] | null {
+        if (item.kind === 'project' && item.project_id != null) {
+            return ['/projects', item.project_id];
+        }
+        return null;
+    }
+
+    trackItem = (_index: number, item: NightPlanItem | NightPlanExcludedItem): string =>
+        `${item.kind}-${item.task_id ?? item.project_id ?? item.object}`;
+
+    ngOnDestroy(): void {
+        this.topBarService.resetState();
     }
 }

--- a/src/app/models/night-plan.ts
+++ b/src/app/models/night-plan.ts
@@ -1,11 +1,12 @@
 /**
  * Night plan types — `GET /api/night-plan`.
  *
- * Source of truth: `hevelius-backend` (`doc/observation-scheduler-plan.md` §4.4,
- * task OS-4) and its `openapi.yaml`. Field naming follows the convention already
- * used by the asteroid visibility endpoint (`*_deg` for angles, `night_start`/
- * `night_end` for the night boundaries, `date` as the evening date YYYY-MM-DD).
+ * Source of truth: hevelius-backend `openapi.yaml` (`NightPlanResponse` and
+ * related schemas) and `hevelius/api/routes/night_plan.py`.
  */
+
+import { Project } from './project';
+import { Task } from './task';
 
 /** Query parameters for `GET /api/night-plan`. */
 export interface NightPlanParams {
@@ -23,55 +24,68 @@ export interface NightPlanParams {
 /** A night plan entry is either an observing task or a project. */
 export type NightPlanItemKind = 'task' | 'project';
 
-/** One observable entry of the plan, with its visibility metadata. */
-export interface NightPlanItem {
-  kind: NightPlanItemKind;
-  /** Set when `kind` is 'task'. */
-  task_id?: number | null;
-  /** Set when `kind` is 'project'. */
-  project_id?: number | null;
-  /** Target name: task object or project name. */
-  object: string;
-  ra: number;
-  decl: number;
-  exposure?: number | null;
-  filter?: string | null;
-  /** Task state; null for projects. */
-  state?: number | null;
-  user_id?: number | null;
-  user_login?: string | null;
-  /** Highest altitude reached during the night, in degrees. */
-  max_altitude_deg?: number | null;
-  /** Time of `max_altitude_deg` (UTC) — the "best time" to observe. */
-  best_time?: string | null;
-  /** Angular distance to the Moon at `best_time`, in degrees. */
+/** Where/when the target was checked as observable during the night. */
+export interface NightPlanVisibility {
+  /** ISO-8601 UTC moment within the night (transit, or nearest night edge). */
+  check_time_utc?: string | null;
+  altitude_deg?: number | null;
+  azimuth_deg?: number | null;
   moon_separation_deg?: number | null;
+  sun_altitude_deg?: number | null;
 }
 
-/** An item the scheduler left out, with the constraints it failed. */
+/** One observable entry of the plan, with nested task/project + visibility. */
+export interface NightPlanItem {
+  kind: NightPlanItemKind;
+  /** Present when `kind` is 'task'. */
+  task?: Task | null;
+  /** Present when `kind` is 'project' (pending subframes only). */
+  project?: Project | null;
+  visibility?: NightPlanVisibility | null;
+}
+
+/**
+ * Machine-readable exclusion reason codes from the scheduler
+ * (`hevelius/night_plan.py`, `hevelius/observability.py`).
+ */
+export type NightPlanExclusionReason =
+  | 'wrong_state'
+  | 'outside_date_window'
+  | 'outside_mount_dec_range'
+  | 'filter_not_on_scope'
+  | 'already_complete'
+  | 'missing_coordinates'
+  | 'below_min_altitude'
+  | 'sun_too_high'
+  | 'moon_too_close'
+  | 'moon_phase_too_bright';
+
+/** An item the scheduler left out, with the constraint it failed. */
 export interface NightPlanExcludedItem {
   kind: NightPlanItemKind;
   task_id?: number | null;
   project_id?: number | null;
-  object: string;
-  /** Human-readable reasons, e.g. "max altitude 12° < min_alt 30°". */
-  reasons: string[];
+  /** Object name (task) or project name. */
+  name?: string | null;
+  reason: NightPlanExclusionReason | string;
 }
 
 /** Response of `GET /api/night-plan`. */
 export interface NightPlanResponse {
-  status?: boolean;
   scope_id: number;
   scope_name?: string | null;
-  /** Evening date (YYYY-MM-DD) the plan was computed for. */
-  date: string;
-  /** Night boundaries (UTC), as computed by the backend. */
-  night_start?: string | null;
-  night_end?: string | null;
-  /** Moon illuminated fraction (0..1) for the night. */
-  moon_phase?: number | null;
+  /** Observing night (YYYY-MM-DD), NINA "local time − 12h" rule. */
+  night_date: string;
+  timezone?: string | null;
+  night_start_utc?: string | null;
+  night_end_utc?: string | null;
+  moonrise_utc?: string | null;
+  moonset_utc?: string | null;
+  /** Moon illuminated fraction at mid-night, 0–100. */
+  moon_illumination_pct?: number | null;
+  generated_at?: string | null;
+  strategy?: 'priority' | 'setting_first' | string | null;
   items: NightPlanItem[];
   /** Present only when the request was made with `explain=true`. */
   excluded?: NightPlanExcludedItem[];
-  msg?: string;
 }

--- a/src/app/models/night-plan.ts
+++ b/src/app/models/night-plan.ts
@@ -1,0 +1,77 @@
+/**
+ * Night plan types — `GET /api/night-plan`.
+ *
+ * Source of truth: `hevelius-backend` (`doc/observation-scheduler-plan.md` §4.4,
+ * task OS-4) and its `openapi.yaml`. Field naming follows the convention already
+ * used by the asteroid visibility endpoint (`*_deg` for angles, `night_start`/
+ * `night_end` for the night boundaries, `date` as the evening date YYYY-MM-DD).
+ */
+
+/** Query parameters for `GET /api/night-plan`. */
+export interface NightPlanParams {
+  /**
+   * Telescope to plan for. Always sent explicitly: the API requires it even
+   * when the user has a `default_scope` preference.
+   */
+  scope_id: number;
+  /** Evening date (YYYY-MM-DD) whose night to plan; omitted = backend's current night. */
+  date?: string;
+  /** When true, the response also carries the excluded items and their reasons. */
+  explain?: boolean;
+}
+
+/** A night plan entry is either an observing task or a project. */
+export type NightPlanItemKind = 'task' | 'project';
+
+/** One observable entry of the plan, with its visibility metadata. */
+export interface NightPlanItem {
+  kind: NightPlanItemKind;
+  /** Set when `kind` is 'task'. */
+  task_id?: number | null;
+  /** Set when `kind` is 'project'. */
+  project_id?: number | null;
+  /** Target name: task object or project name. */
+  object: string;
+  ra: number;
+  decl: number;
+  exposure?: number | null;
+  filter?: string | null;
+  /** Task state; null for projects. */
+  state?: number | null;
+  user_id?: number | null;
+  user_login?: string | null;
+  /** Highest altitude reached during the night, in degrees. */
+  max_altitude_deg?: number | null;
+  /** Time of `max_altitude_deg` (UTC) — the "best time" to observe. */
+  best_time?: string | null;
+  /** Angular distance to the Moon at `best_time`, in degrees. */
+  moon_separation_deg?: number | null;
+}
+
+/** An item the scheduler left out, with the constraints it failed. */
+export interface NightPlanExcludedItem {
+  kind: NightPlanItemKind;
+  task_id?: number | null;
+  project_id?: number | null;
+  object: string;
+  /** Human-readable reasons, e.g. "max altitude 12° < min_alt 30°". */
+  reasons: string[];
+}
+
+/** Response of `GET /api/night-plan`. */
+export interface NightPlanResponse {
+  status?: boolean;
+  scope_id: number;
+  scope_name?: string | null;
+  /** Evening date (YYYY-MM-DD) the plan was computed for. */
+  date: string;
+  /** Night boundaries (UTC), as computed by the backend. */
+  night_start?: string | null;
+  night_end?: string | null;
+  /** Moon illuminated fraction (0..1) for the night. */
+  moon_phase?: number | null;
+  items: NightPlanItem[];
+  /** Present only when the request was made with `explain=true`. */
+  excluded?: NightPlanExcludedItem[];
+  msg?: string;
+}

--- a/src/app/services/night-plan.service.spec.ts
+++ b/src/app/services/night-plan.service.spec.ts
@@ -3,7 +3,7 @@ import { HttpTestingController, provideHttpClientTesting } from '@angular/common
 import { NightPlanService } from './night-plan.service';
 import { provideHttpClient } from '@angular/common/http';
 import { Hevelius } from 'src/hevelius';
-import { Task } from '../models/task';
+import { NightPlanResponse } from '../models/night-plan';
 
 describe('NightPlanService', () => {
   let service: NightPlanService;
@@ -28,69 +28,74 @@ describe('NightPlanService', () => {
     expect(service).toBeTruthy();
   });
 
-  it('should load night plan with default scope_id', () => {
-    const mockTasks = {
-      tasks: [
+  it('should GET the night plan with an explicit scope_id', () => {
+    const mockResponse: NightPlanResponse = {
+      status: true,
+      scope_id: 5,
+      scope_name: 'Test scope',
+      date: '2026-08-06',
+      night_start: '2026-08-06 20:11:00',
+      night_end: '2026-08-07 03:02:00',
+      moon_phase: 0.42,
+      items: [
         {
+          kind: 'task',
           task_id: 1,
-          user_id: 1,
-          aavso_id: 'TEST1',
-          object: 'Test Object 1',
-          ra: 12.34,
-          decl: 56.78,
-          exposure: 60,
-          state: 1
-        },
-        {
-          task_id: 2,
-          user_id: 1,
-          aavso_id: 'TEST2',
-          object: 'Test Object 2',
-          ra: 23.45,
-          decl: 67.89,
-          exposure: 120,
-          state: 1
+          object: 'M31',
+          ra: 0.712,
+          decl: 41.27,
+          exposure: 300,
+          state: 1,
+          max_altitude_deg: 62.3,
+          best_time: '2026-08-07 01:20:00',
+          moon_separation_deg: 88.1
         }
-      ] as Task[]
+      ]
     };
 
-    service.loadNightPlan();
+    let received: NightPlanResponse | null = null;
+    service.getNightPlan({ scope_id: 5 }).subscribe(response => { received = response; });
 
-    const req = httpMock.expectOne(`${Hevelius.apiUrl}/night-plan`);
-    expect(req.request.method).toBe('POST');
-    expect(req.request.body).toEqual({ scope_id: 3 }); // Default scope_id
+    const req = httpMock.expectOne(r => r.url === `${Hevelius.apiUrl}/night-plan`);
+    expect(req.request.method).toBe('GET');
+    expect(req.request.params.get('scope_id')).toBe('5');
+    expect(req.request.params.has('date')).toBe(false);
+    expect(req.request.params.has('explain')).toBe(false);
 
-    req.flush(mockTasks);
-
-    service.connect().subscribe(tasks => {
-      expect(tasks).toEqual(mockTasks.tasks);
-    });
-
-    service.getTaskCount().subscribe(count => {
-      expect(count).toBe(2);
-    });
+    req.flush(mockResponse);
+    expect(received).toEqual(mockResponse);
   });
 
-  it('should load night plan with custom scope_id', () => {
-    service.loadNightPlan({ scope_id: 5 });
+  it('should pass date and explain when set', () => {
+    service.getNightPlan({ scope_id: 3, date: '2026-08-06', explain: true }).subscribe();
 
-    const req = httpMock.expectOne(`${Hevelius.apiUrl}/night-plan`);
-    expect(req.request.method).toBe('POST');
-    expect(req.request.body).toEqual({ scope_id: 5 });
+    const req = httpMock.expectOne(r => r.url === `${Hevelius.apiUrl}/night-plan`);
+    expect(req.request.params.get('scope_id')).toBe('3');
+    expect(req.request.params.get('date')).toBe('2026-08-06');
+    expect(req.request.params.get('explain')).toBe('true');
+
+    req.flush({ scope_id: 3, date: '2026-08-06', items: [], excluded: [] } as NightPlanResponse);
   });
 
-  it('should handle error response', () => {
-    service.loadNightPlan();
+  it('should omit explain when it is false', () => {
+    service.getNightPlan({ scope_id: 3, explain: false }).subscribe();
 
-    const req = httpMock.expectOne(`${Hevelius.apiUrl}/night-plan`);
-    req.error(new ErrorEvent('Network error'));
+    const req = httpMock.expectOne(r => r.url === `${Hevelius.apiUrl}/night-plan`);
+    expect(req.request.params.has('explain')).toBe(false);
 
-    service.connect().subscribe(tasks => {
-      expect(tasks).toEqual([]);
+    req.flush({ scope_id: 3, date: '2026-08-06', items: [] } as NightPlanResponse);
+  });
+
+  it('should surface errors to the caller', () => {
+    let errored = false;
+    service.getNightPlan({ scope_id: 3 }).subscribe({
+      next: () => { /* not reached */ },
+      error: () => { errored = true; }
     });
 
-    service.getTaskCount().subscribe(count => {
-      expect(count).toBe(0);
-    });
+    const req = httpMock.expectOne(r => r.url === `${Hevelius.apiUrl}/night-plan`);
+    req.flush({ msg: 'boom' }, { status: 500, statusText: 'Server Error' });
+
+    expect(errored).toBe(true);
   });
 });

--- a/src/app/services/night-plan.service.spec.ts
+++ b/src/app/services/night-plan.service.spec.ts
@@ -4,6 +4,7 @@ import { NightPlanService } from './night-plan.service';
 import { provideHttpClient } from '@angular/common/http';
 import { Hevelius } from 'src/hevelius';
 import { NightPlanResponse } from '../models/night-plan';
+import { Task } from '../models/task';
 
 describe('NightPlanService', () => {
   let service: NightPlanService;
@@ -30,25 +31,30 @@ describe('NightPlanService', () => {
 
   it('should GET the night plan with an explicit scope_id', () => {
     const mockResponse: NightPlanResponse = {
-      status: true,
       scope_id: 5,
       scope_name: 'Test scope',
-      date: '2026-08-06',
-      night_start: '2026-08-06 20:11:00',
-      night_end: '2026-08-07 03:02:00',
-      moon_phase: 0.42,
+      night_date: '2026-08-06',
+      night_start_utc: '2026-08-06T20:11:00Z',
+      night_end_utc: '2026-08-07T03:02:00Z',
+      moon_illumination_pct: 42,
       items: [
         {
           kind: 'task',
-          task_id: 1,
-          object: 'M31',
-          ra: 0.712,
-          decl: 41.27,
-          exposure: 300,
-          state: 1,
-          max_altitude_deg: 62.3,
-          best_time: '2026-08-07 01:20:00',
-          moon_separation_deg: 88.1
+          task: {
+            task_id: 1,
+            user_id: 3,
+            aavso_id: '',
+            object: 'M31',
+            ra: 0.712,
+            decl: 41.27,
+            exposure: 300,
+            state: 1
+          } as Task,
+          visibility: {
+            altitude_deg: 62.3,
+            check_time_utc: '2026-08-07T01:20:00Z',
+            moon_separation_deg: 88.1
+          }
         }
       ]
     };
@@ -74,7 +80,12 @@ describe('NightPlanService', () => {
     expect(req.request.params.get('date')).toBe('2026-08-06');
     expect(req.request.params.get('explain')).toBe('true');
 
-    req.flush({ scope_id: 3, date: '2026-08-06', items: [], excluded: [] } as NightPlanResponse);
+    req.flush({
+      scope_id: 3,
+      night_date: '2026-08-06',
+      items: [],
+      excluded: []
+    } as NightPlanResponse);
   });
 
   it('should omit explain when it is false', () => {
@@ -83,7 +94,7 @@ describe('NightPlanService', () => {
     const req = httpMock.expectOne(r => r.url === `${Hevelius.apiUrl}/night-plan`);
     expect(req.request.params.has('explain')).toBe(false);
 
-    req.flush({ scope_id: 3, date: '2026-08-06', items: [] } as NightPlanResponse);
+    req.flush({ scope_id: 3, night_date: '2026-08-06', items: [] } as NightPlanResponse);
   });
 
   it('should surface errors to the caller', () => {

--- a/src/app/services/night-plan.service.ts
+++ b/src/app/services/night-plan.service.ts
@@ -1,59 +1,33 @@
 import { Injectable, inject } from '@angular/core';
-import { HttpClient } from '@angular/common/http';
-import { Observable, BehaviorSubject } from 'rxjs';
-import { DataSource } from '@angular/cdk/collections';
-import { Task } from '../models/task';
+import { HttpClient, HttpParams } from '@angular/common/http';
+import { Observable } from 'rxjs';
 import { Hevelius } from 'src/hevelius';
-
-interface NightPlanParams {
-    scope_id?: number;
-}
-
-interface NightPlanResponse {
-    tasks: Task[];
-}
+import { NightPlanParams, NightPlanResponse } from '../models/night-plan';
 
 @Injectable({
     providedIn: 'root'
 })
-export class NightPlanService implements DataSource<Task> {
+export class NightPlanService {
     private http = inject(HttpClient);
 
-    private tasks = new BehaviorSubject<Task[]>([]);
-    private defaultScopeId = 3;
-    private taskCount = new BehaviorSubject<number>(0);
+    private apiUrl = `${Hevelius.apiUrl}/night-plan`;
 
-    connect(): Observable<Task[]> {
-        return this.tasks.asObservable();
-    }
-
-    disconnect(): void {
-        this.tasks.complete();
-        this.taskCount.complete();
-    }
-
-    getTaskCount(): Observable<number> {
-        return this.taskCount.asObservable();
-    }
-
-    loadNightPlan(params: NightPlanParams = {}) {
-        if (!params.scope_id) {
-            params.scope_id = this.defaultScopeId;
+    /**
+     * GET /api/night-plan — the plan for one telescope and one night.
+     *
+     * `scope_id` is always sent explicitly; the backend requires it even when
+     * the user has a `default_scope` preference. `date` is omitted when unset,
+     * which lets the backend pick the current night itself.
+     */
+    getNightPlan(params: NightPlanParams): Observable<NightPlanResponse> {
+        let httpParams = new HttpParams().set('scope_id', String(params.scope_id));
+        if (params.date) {
+            httpParams = httpParams.set('date', params.date);
+        }
+        if (params.explain) {
+            httpParams = httpParams.set('explain', 'true');
         }
 
-        this.http.post<NightPlanResponse>(`${Hevelius.apiUrl}/night-plan`, params)
-            .subscribe({
-                next: (data) => {
-                    if (data && data.tasks) {
-                        this.tasks.next(data.tasks);
-                        this.taskCount.next(data.tasks.length);
-                    }
-                },
-                error: (error) => {
-                    console.log('Error when requesting night plan data:', error);
-                    this.tasks.next([]);
-                    this.taskCount.next(0);
-                }
-            });
+        return this.http.get<NightPlanResponse>(this.apiUrl, { params: httpParams });
     }
 }


### PR DESCRIPTION
The page hard-coded scope_id = 3, had no date picker, and rendered a plain
task table with none of the visibility metadata the scheduler computes.

- NightPlanService now calls GET /api/night-plan with scope_id always sent
  explicitly (the API requires it even when the user has a default_scope),
  plus optional date and explain query params.
- New src/app/models/night-plan.ts holds the request/response types.
- The page gets a telescope selector (active telescopes only, defaulted from
  GET /api/users/me/preferences -> default_scope, falling back to the first
  active telescope) and a date picker defaulting to tonight, with a "Tonight"
  shortcut.
- Plan entries cover both tasks and projects and show max altitude, Moon
  separation, and best observing time; projects link to their detail page.
- An "Explain" toggle requests explain=true and lists the excluded candidates
  with the constraints they failed.
- Night Plan is now reachable from the main menu; it was route-only before.

Refs #164 (OS-5)

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_019fvYs7BUyhncR44cGM9UoW